### PR TITLE
Auth Fix

### DIFF
--- a/src/git/auth.rs
+++ b/src/git/auth.rs
@@ -420,10 +420,15 @@ password ghp_api_token_456
             .expect_var()
             .with(mockall::predicate::eq("GITHUB_TOKEN"))
             .times(1)
-            .returning(|_| Ok("ghp_valid_env_token_1234567890123456789012345678901234567890".to_string()));
+            .returning(|_| {
+                Ok("ghp_valid_env_token_1234567890123456789012345678901234567890".to_string())
+            });
 
         let token = get_token("https://github.com", &mock_env);
-        assert_eq!(token, Some("ghp_valid_env_token_1234567890123456789012345678901234567890".to_string()));
+        assert_eq!(
+            token,
+            Some("ghp_valid_env_token_1234567890123456789012345678901234567890".to_string())
+        );
 
         let client = create_authenticated_client("https://github.com", token);
         assert!(client.is_ok());


### PR DESCRIPTION
During initial development of ghqcr, there were issues with subcommands during auth determination. Because of this, we started checking if this was being run in an R context (like ghqcr). This would then skip looking in the git credential manager, which was fine for development, but is not acceptable for long term use as that's how `gitcreds` stores auth

Revisiting it was a different, now resolved issue which was causing issues during auth and the subprocess is acceptable. Therefore the requirement was lifted. Additionally, added `gh auth token` as a method to find the token.