### PR TITLE
Track file renaming after issue creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Each file under QC has a dedicated GitHub Issue. `ghqc` manages the full issue l
 | [`ghqc issue approve`](docs/issue-approve.md) | Approve the issue at a specific commit and close it |
 | [`ghqc issue unapprove`](docs/issue-unapprove.md) | Reopen an approved issue with a reason |
 | [`ghqc issue status`](docs/issue-status.md) | Print the QC status, git status, and checklist progress |
+| [`ghqc issue rename`](docs/issue-rename.md) | Confirm a detected file rename and update the issue title |
 
 ### Milestones
 
@@ -190,6 +191,7 @@ An example configuration repository is available at [a2-ai/ghqc.example_config_r
 - [Issue: Approve](docs/issue-approve.md)
 - [Issue: Unapprove](docs/issue-unapprove.md)
 - [Issue: Status](docs/issue-status.md)
+- [Issue: Rename](docs/issue-rename.md)
 - [Milestone: Status](docs/milestone-status.md)
 - [Milestone: Record](docs/milestone-record.md)
 - [Milestone: Archive](docs/milestone-archive.md)

--- a/docs/issue-rename.md
+++ b/docs/issue-rename.md
@@ -1,0 +1,68 @@
+# Issue: Rename
+
+```shell
+ghqc issue rename
+```
+
+Confirms a detected file rename: updates the issue title to the new file path and appends a `## File History` entry to the issue body recording the old name, new name, and HEAD commit. A timeline comment is also posted to the issue so the rename is visible in the thread.
+
+`ghqc issue status` and `ghqc milestone status` will alert when renames are detected. Run this command to confirm them.
+
+Running the command with no arguments enters interactive mode.
+
+## Steps
+
+### 1. Select a Milestone
+
+```shell
+? Select a milestone:
+> 🎯 Milestone 1
+  🎯 QC Round 2
+  🎯 EDA
+```
+
+### 2. Renames Detected and Confirmed
+
+`ghqc` checks open issues in the selected milestone against the current git HEAD tree and identifies any files that have been renamed in a committed change.
+
+```shell
+⚠️  Detected 1 file rename(s):
+  `scripts/file_b.R` → `scripts/file_b_renamed.R` (issue #42)
+? Update issue #42 title and record rename in body? (Y/n)
+  ✓ Issue #42 updated.
+
+✅ Confirmed 1 rename(s).
+```
+
+Choose **Y** to update the issue, or **n** to skip. If no renames are detected, the command reports that and exits.
+
+## Non-interactive Usage
+
+Provide `--milestone` and `--file` to confirm a specific rename without any prompts. The new file path is auto-detected from git history.
+
+```shell
+ghqc issue rename --milestone "Milestone 1" --file scripts/file_b.R
+```
+
+`--file` requires `--milestone`.
+
+| Flag | Description |
+|---|---|
+| `-m, --milestone` | Milestone name. Skips the milestone selection prompt. |
+| `-f, --file` | Old file path (current issue title). Auto-detects the rename target. Requires `--milestone`. |
+
+## File History
+
+When a rename is confirmed, a `## File History` section is appended (or updated) in the issue body:
+
+```markdown
+## File History
+* `scripts/file_b.R` → `scripts/file_b_renamed.R` (commit: abc1234)
+```
+
+This history is used internally by `ghqc` to correctly attribute commits made against the old file name when computing QC and git status.
+
+## See Also
+
+- [`ghqc issue status`](issue-status.md) — alerts about detected renames for a single issue
+- [`ghqc milestone status`](milestone-status.md) — alerts about detected renames across a milestone

--- a/docs/issue-status.md
+++ b/docs/issue-status.md
@@ -67,6 +67,19 @@ ghqc issue status --milestone "Milestone 1" --file scripts/file_1.qmd
 | `Approved` | Issue has been approved and closed |
 | `Changes After Approval` | File changed after approval was given |
 
+## File Rename Alerts
+
+If `ghqc` detects that a file tracked by an open issue has been renamed in a committed change, it prints a warning before the status output:
+
+```shell
+⚠️  Detected 1 file rename(s):
+  `scripts/file_b.R` → `scripts/file_b_renamed.R` (issue #42)
+  Run `ghqc issue rename` to confirm.
+```
+
+Run [`ghqc issue rename`](issue-rename.md) to update the issue title and record the rename in the issue body.
+
 ## See Also
 
 - [`ghqc milestone status`](milestone-status.md) — tabular summary across multiple milestones
+- [`ghqc issue rename`](issue-rename.md) — confirm a detected file rename

--- a/docs/milestone-status.md
+++ b/docs/milestone-status.md
@@ -68,7 +68,20 @@ ghqc milestone status --all-milestones
 | Git Status | Whether the file is up to date with its tracked remote |
 | Checklist | Completed checklist items out of total |
 
+## File Rename Alerts
+
+Before computing status, `ghqc` checks open issues for files that have been renamed in a committed change. If any are found, a warning is printed above the table:
+
+```shell
+⚠️  Detected 1 file rename(s):
+  `scripts/file_b.R` → `scripts/file_b_renamed.R` (issue #42)
+  Run `ghqc issue rename` to confirm.
+```
+
+Run [`ghqc issue rename`](issue-rename.md) to update the issue title and record the rename in the issue body.
+
 ## See Also
 
 - [`ghqc issue status`](issue-status.md) — detailed status for a single issue
+- [`ghqc issue rename`](issue-rename.md) — confirm a detected file rename
 - [`ghqc milestone record`](milestone-record.md) — generate a PDF record once issues are approved

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -147,6 +147,34 @@ paths:
         '404':
           description: Milestone not found
 
+  /milestones/{number}/renames:
+    get:
+      summary: List detected file renames for open issues in a milestone
+      description: |
+        Checks open issues in the milestone against the current git HEAD tree and returns
+        any files that have been renamed in a committed change. Used to prompt users to
+        confirm renames via `POST /issues/{number}/rename`.
+      operationId: listMilestoneRenames
+      tags: [milestones]
+      parameters:
+        - name: number
+          in: path
+          required: true
+          description: Milestone number
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: List of detected renames (may be empty)
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DetectedRename'
+        '404':
+          description: Milestone not found
+
   /issues/status:
     get:
       summary: Batch get issue statuses
@@ -452,6 +480,37 @@ paths:
             text/html:
               schema:
                 type: string
+
+  /issues/{number}/rename:
+    post:
+      summary: Confirm a detected file rename
+      description: |
+        Updates the issue title to `new_path`, appends a `## File History` entry to the
+        issue body recording the old name, new name, and HEAD commit hash, and posts a
+        timeline comment so the rename is visible in the issue thread.
+
+        This is the confirmation step after `GET /milestones/{number}/renames` detects a rename.
+      operationId: renameIssue
+      tags: [issues]
+      parameters:
+        - name: number
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RenameIssueRequest'
+      responses:
+        '204':
+          description: Issue renamed successfully
+        '400':
+          description: new_path is empty or whitespace-only
+        '404':
+          description: Issue not found
 
   /issues/{number}/blocked:
     get:
@@ -1685,3 +1744,48 @@ components:
           type: string
           description: Absolute path where the archive was written
           example: "/path/to/repo-milestone.tar.gz"
+
+    DetectedRename:
+      type: object
+      required: [issue_number, old_path, new_path]
+      description: A file rename detected for an open QC issue
+      properties:
+        issue_number:
+          type: integer
+          description: The issue whose title (file path) was renamed
+        old_path:
+          type: string
+          description: The old file path (current issue title)
+          example: "scripts/file_b.R"
+        new_path:
+          type: string
+          description: The new file path detected in git history
+          example: "scripts/file_b_renamed.R"
+
+    RenameIssueRequest:
+      type: object
+      required: [new_path]
+      description: Request body for confirming a file rename
+      properties:
+        new_path:
+          type: string
+          description: The new file path to rename the issue title to
+          example: "scripts/file_b_renamed.R"
+
+    FileRenameEvent:
+      type: object
+      required: [old_path, new_path, commit]
+      description: A single rename entry recorded in an issue's File History section
+      properties:
+        old_path:
+          type: string
+          description: The file path before the rename
+          example: "scripts/file_b.R"
+        new_path:
+          type: string
+          description: The file path after the rename
+          example: "scripts/file_b_renamed.R"
+        commit:
+          type: string
+          description: The HEAD commit hash at the time the rename was confirmed
+          example: "abc1234"

--- a/src/api/routes/issues.rs
+++ b/src/api/routes/issues.rs
@@ -13,14 +13,15 @@ use crate::create::QCIssueError;
 use crate::git::{GitFileOps, GitHelpers, GitHubApiError};
 use crate::{
     FileRenameEvent, GitProvider, QCEntry, batch_post_qc_entries, create_labels_if_needed,
-    file_history_section, get_repo_users, head_commit_hash, parse_file_history, splice_file_history,
+    file_history_section, get_repo_users, head_commit_hash, parse_file_history,
+    splice_file_history,
 };
-use octocrab::models::issues::Issue as OctocrabIssue;
 use axum::{
     Json,
     extract::{Path, Query, State},
     http::StatusCode,
 };
+use octocrab::models::issues::Issue as OctocrabIssue;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -416,7 +417,9 @@ pub async fn rename_issue<G: GitProvider + 'static>(
     Json(request): Json<RenameIssueRequest>,
 ) -> Result<StatusCode, ApiError> {
     if request.new_path.trim().is_empty() {
-        return Err(ApiError::BadRequest("new_path must not be empty".to_string()));
+        return Err(ApiError::BadRequest(
+            "new_path must not be empty".to_string(),
+        ));
     }
 
     // Fetch the current issue to get its title (old path) and body.
@@ -458,7 +461,12 @@ pub async fn rename_issue<G: GitProvider + 'static>(
         .await
         .map_err(ApiError::from)?;
 
-    log::info!("Renamed issue #{number}: {:?} → {:?} (commit {})", old_path, new_path, commit_hash);
+    log::info!(
+        "Renamed issue #{number}: {:?} → {:?} (commit {})",
+        old_path,
+        new_path,
+        commit_hash
+    );
 
     // Post a timeline comment so the rename is visible in the issue thread.
     // A failure here is non-fatal: the title and body are already updated.
@@ -474,4 +482,3 @@ pub async fn rename_issue<G: GitProvider + 'static>(
 
     Ok(StatusCode::NO_CONTENT)
 }
-

--- a/src/api/routes/issues.rs
+++ b/src/api/routes/issues.rs
@@ -13,7 +13,7 @@ use crate::create::QCIssueError;
 use crate::git::{GitFileOps, GitHelpers, GitHubApiError};
 use crate::{
     FileRenameEvent, GitProvider, QCEntry, batch_post_qc_entries, create_labels_if_needed,
-    file_history_section, get_repo_users, head_commit_hash, parse_file_history,
+    file_history_section, get_repo_users, head_commit_hash, parse_file_history, splice_file_history,
 };
 use octocrab::models::issues::Issue as OctocrabIssue;
 use axum::{
@@ -475,47 +475,3 @@ pub async fn rename_issue<G: GitProvider + 'static>(
     Ok(StatusCode::NO_CONTENT)
 }
 
-/// Insert (or replace) the `## File History` section in the issue body.
-///
-/// If the section already exists, it is replaced in-place.
-/// Otherwise it is inserted immediately before the checklist heading (`# `)
-/// or appended at the end.
-fn splice_file_history(body: &str, history_section: &str) -> String {
-    let history_trimmed = history_section.trim_end();
-
-    // If a File History section already exists, replace it in-place.
-    if let Some(start) = body.find("## File History") {
-        let before = body[..start].trim_end();
-        let after_header = &body[start + "## File History".len()..];
-        // Find the next level-2 heading (start of the following section).
-        let after = match after_header.find("\n## ") {
-            Some(p) => &after_header[p + 1..], // keep the leading newline before "## "
-            None => "",
-        };
-        if after.is_empty() {
-            return format!("{}\n{}", before, history_trimmed);
-        }
-        return format!("{}\n{}\n\n{}", before, history_trimmed, after);
-    }
-
-    // Insert before the checklist heading or append.
-    if let Some(checklist_pos) = find_checklist_start(body) {
-        let before = body[..checklist_pos].trim_end();
-        let rest = &body[checklist_pos..];
-        format!("{}\n\n{}\n\n{}", before, history_trimmed, rest)
-    } else {
-        format!("{}\n\n{}", body.trim_end(), history_trimmed)
-    }
-}
-
-/// Find the byte offset of the first `# ` heading that is NOT `## ` (the checklist heading).
-fn find_checklist_start(body: &str) -> Option<usize> {
-    let mut pos = 0usize;
-    for line in body.lines() {
-        if line.starts_with("# ") && !line.starts_with("## ") {
-            return Some(pos);
-        }
-        pos += line.len() + 1; // +1 for the '\n'
-    }
-    None
-}

--- a/src/api/routes/issues.rs
+++ b/src/api/routes/issues.rs
@@ -8,15 +8,20 @@ use crate::api::types::{
     BlockingQCItemWithStatus, BlockingQCStatus, CreateIssueRequest, CreateIssueResponse, Issue,
     IssueStatusError, IssueStatusErrorKind, IssueStatusResponse, QCStatusEnum,
 };
+use crate::comment_system::CommentBody;
 use crate::create::QCIssueError;
-use crate::git::GitHubApiError;
-use crate::{GitProvider, QCEntry, batch_post_qc_entries, create_labels_if_needed, get_repo_users};
+use crate::git::{GitFileOps, GitHelpers, GitHubApiError};
+use crate::{
+    FileRenameEvent, GitProvider, QCEntry, batch_post_qc_entries, create_labels_if_needed,
+    file_history_section, get_repo_users, head_commit_hash, parse_file_history,
+};
+use octocrab::models::issues::Issue as OctocrabIssue;
 use axum::{
     Json,
     extract::{Path, Query, State},
     http::StatusCode,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::PathBuf;
 
@@ -368,4 +373,149 @@ pub async fn get_blocked_issues<G: GitProvider + 'static>(
     }));
 
     Ok(Json(blocked_statuses))
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RenameIssueRequest {
+    pub new_path: String,
+}
+
+/// Comment body posted to the issue timeline when a rename is confirmed.
+struct RenameComment {
+    issue: OctocrabIssue,
+    old_path: String,
+    new_path: String,
+    commit: String,
+}
+
+impl CommentBody for RenameComment {
+    fn generate_body(&self, _git_info: &(impl GitHelpers + GitFileOps)) -> String {
+        format!(
+            "# QC File Rename\n`{}` \u{2192} `{}` (commit: {})",
+            self.old_path, self.new_path, self.commit
+        )
+    }
+
+    fn issue(&self) -> &OctocrabIssue {
+        &self.issue
+    }
+
+    fn title(&self) -> &str {
+        "QC File Rename"
+    }
+}
+
+/// POST /api/issues/{number}/rename
+///
+/// Confirm a detected file rename: updates the issue title to `new_path`,
+/// appends a `## File History` entry to the issue body recording the rename,
+/// and posts a timeline comment so the rename is visible in the issue thread.
+pub async fn rename_issue<G: GitProvider + 'static>(
+    State(state): State<AppState<G>>,
+    Path(number): Path<u64>,
+    Json(request): Json<RenameIssueRequest>,
+) -> Result<StatusCode, ApiError> {
+    if request.new_path.trim().is_empty() {
+        return Err(ApiError::BadRequest("new_path must not be empty".to_string()));
+    }
+
+    // Fetch the current issue to get its title (old path) and body.
+    let raw_issue = state
+        .git_info()
+        .get_issue(number)
+        .await
+        .map_err(ApiError::from)?;
+
+    let old_path = raw_issue.title.clone();
+    let current_body = raw_issue.body.as_deref().unwrap_or("").to_string();
+
+    // Get the HEAD commit hash to record in history.
+    let repo_path = state.git_info().path().to_path_buf();
+    let commit_hash = tokio::task::spawn_blocking(move || {
+        head_commit_hash(&repo_path).unwrap_or_else(|| "unknown".to_string())
+    })
+    .await
+    .unwrap_or_else(|_| "unknown".to_string());
+
+    let new_path = request.new_path;
+
+    // Build the updated file history.
+    let mut events = parse_file_history(&current_body);
+    events.push(FileRenameEvent {
+        old_path: old_path.clone(),
+        new_path: new_path.clone(),
+        commit: commit_hash.clone(),
+    });
+    let history_section = file_history_section(&events);
+
+    // Splice history section into the body: insert before the checklist (first `# ` heading)
+    // or append if no such heading exists.
+    let new_body = splice_file_history(&current_body, &history_section);
+
+    state
+        .git_info()
+        .update_issue(number, Some(new_path.clone()), Some(new_body))
+        .await
+        .map_err(ApiError::from)?;
+
+    log::info!("Renamed issue #{number}: {:?} → {:?} (commit {})", old_path, new_path, commit_hash);
+
+    // Post a timeline comment so the rename is visible in the issue thread.
+    // A failure here is non-fatal: the title and body are already updated.
+    let rename_comment = RenameComment {
+        issue: raw_issue,
+        old_path,
+        new_path,
+        commit: commit_hash,
+    };
+    if let Err(e) = state.git_info().post_comment(&rename_comment).await {
+        log::warn!("Failed to post rename comment to issue #{number}: {e}");
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Insert (or replace) the `## File History` section in the issue body.
+///
+/// If the section already exists, it is replaced in-place.
+/// Otherwise it is inserted immediately before the checklist heading (`# `)
+/// or appended at the end.
+fn splice_file_history(body: &str, history_section: &str) -> String {
+    let history_trimmed = history_section.trim_end();
+
+    // If a File History section already exists, replace it in-place.
+    if let Some(start) = body.find("## File History") {
+        let before = body[..start].trim_end();
+        let after_header = &body[start + "## File History".len()..];
+        // Find the next level-2 heading (start of the following section).
+        let after = match after_header.find("\n## ") {
+            Some(p) => &after_header[p + 1..], // keep the leading newline before "## "
+            None => "",
+        };
+        if after.is_empty() {
+            return format!("{}\n{}", before, history_trimmed);
+        }
+        return format!("{}\n{}\n\n{}", before, history_trimmed, after);
+    }
+
+    // Insert before the checklist heading or append.
+    if let Some(checklist_pos) = find_checklist_start(body) {
+        let before = body[..checklist_pos].trim_end();
+        let rest = &body[checklist_pos..];
+        format!("{}\n\n{}\n\n{}", before, history_trimmed, rest)
+    } else {
+        format!("{}\n\n{}", body.trim_end(), history_trimmed)
+    }
+}
+
+/// Find the byte offset of the first `# ` heading that is NOT `## ` (the checklist heading).
+fn find_checklist_start(body: &str) -> Option<usize> {
+    let mut pos = 0usize;
+    for line in body.lines() {
+        if line.starts_with("# ") && !line.starts_with("## ") {
+            return Some(pos);
+        }
+        pos += line.len() + 1; // +1 for the '\n'
+    }
+    None
 }

--- a/src/api/routes/milestones.rs
+++ b/src/api/routes/milestones.rs
@@ -79,11 +79,9 @@ pub async fn list_milestone_renames<G: GitProvider + 'static>(
     let repo_path = state.git_info().path().to_path_buf();
     let issue_paths: Vec<PathBuf> = open_issue_paths.iter().map(|(_, p)| p.clone()).collect();
 
-    let raw_renames = tokio::task::spawn_blocking(move || {
-        detect_renames(&repo_path, &issue_paths)
-    })
-    .await
-    .map_err(|e| ApiError::Internal(format!("Rename detection task failed: {}", e)))?;
+    let raw_renames = tokio::task::spawn_blocking(move || detect_renames(&repo_path, &issue_paths))
+        .await
+        .map_err(|e| ApiError::Internal(format!("Rename detection task failed: {}", e)))?;
 
     // Map old_path back to issue_number
     let response: Vec<DetectedRename> = raw_renames

--- a/src/api/routes/milestones.rs
+++ b/src/api/routes/milestones.rs
@@ -1,9 +1,12 @@
 //! Milestone endpoints.
 
+use std::path::PathBuf;
+
 use crate::GitProvider;
 use crate::api::error::ApiError;
 use crate::api::state::AppState;
-use crate::api::types::{CreateMilestoneRequest, Issue, Milestone};
+use crate::api::types::{CreateMilestoneRequest, DetectedRename, Issue, Milestone};
+use crate::detect_renames;
 use axum::{
     Json,
     extract::{Path, State},
@@ -48,6 +51,54 @@ pub async fn list_milestone_issues<G: GitProvider + 'static>(
     let issues = state.git_info().get_issues(Some(number)).await?;
 
     let response: Vec<Issue> = issues.into_iter().map(Issue::from).collect();
+
+    Ok(Json(response))
+}
+
+/// GET /api/milestones/{number}/renames
+///
+/// Detect which open-issue file paths in this milestone have been renamed in git.
+/// Returns one entry per detected rename: {issue_number, old_path, new_path}.
+pub async fn list_milestone_renames<G: GitProvider + 'static>(
+    State(state): State<AppState<G>>,
+    Path(number): Path<u64>,
+) -> Result<Json<Vec<DetectedRename>>, ApiError> {
+    let issues = state.git_info().get_issues(Some(number)).await?;
+
+    // Only check open issues — closed ones are done and don't need rename tracking.
+    let open_issue_paths: Vec<(u64, PathBuf)> = issues
+        .into_iter()
+        .filter(|i| matches!(i.state, octocrab::models::IssueState::Open))
+        .map(|i| (i.number as u64, PathBuf::from(&i.title)))
+        .collect();
+
+    if open_issue_paths.is_empty() {
+        return Ok(Json(vec![]));
+    }
+
+    let repo_path = state.git_info().path().to_path_buf();
+    let issue_paths: Vec<PathBuf> = open_issue_paths.iter().map(|(_, p)| p.clone()).collect();
+
+    let raw_renames = tokio::task::spawn_blocking(move || {
+        detect_renames(&repo_path, &issue_paths)
+    })
+    .await
+    .map_err(|e| ApiError::Internal(format!("Rename detection task failed: {}", e)))?;
+
+    // Map old_path back to issue_number
+    let response: Vec<DetectedRename> = raw_renames
+        .into_iter()
+        .filter_map(|(old_path, new_path)| {
+            open_issue_paths
+                .iter()
+                .find(|(_, p)| *p == old_path)
+                .map(|(issue_number, _)| DetectedRename {
+                    issue_number: *issue_number,
+                    old_path: old_path.to_string_lossy().to_string(),
+                    new_path: new_path.to_string_lossy().to_string(),
+                })
+        })
+        .collect();
 
     Ok(Json(response))
 }

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -48,12 +48,20 @@ pub fn create_router<G: GitProvider + 'static>(state: AppState<G>) -> Router {
             "/api/milestones/{number}/issues",
             get(milestones::list_milestone_issues).post(issues::create_issues),
         )
+        .route(
+            "/api/milestones/{number}/renames",
+            get(milestones::list_milestone_renames),
+        )
         // Issues
         .route("/api/issues/status", get(issues::batch_get_issue_status))
         .route("/api/issues/{number}", get(issues::get_issue))
         .route(
             "/api/issues/{number}/blocked",
             get(issues::get_blocked_issues),
+        )
+        .route(
+            "/api/issues/{number}/rename",
+            post(issues::rename_issue),
         )
         // Comments & Actions
         .route(

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -59,10 +59,7 @@ pub fn create_router<G: GitProvider + 'static>(state: AppState<G>) -> Router {
             "/api/issues/{number}/blocked",
             get(issues::get_blocked_issues),
         )
-        .route(
-            "/api/issues/{number}/rename",
-            post(issues::rename_issue),
-        )
+        .route("/api/issues/{number}/rename", post(issues::rename_issue))
         // Comments & Actions
         .route(
             "/api/issues/{number}/comment",

--- a/src/api/tests/cases/issues/rename_issue_empty_path.yaml
+++ b/src/api/tests/cases/issues/rename_issue_empty_path.yaml
@@ -1,0 +1,19 @@
+name: "POST /api/issues/{number}/rename - empty path rejected"
+description: "Rename with empty new_path returns 400"
+
+fixtures:
+  issues:
+    - type: mock
+      number: 1
+      title: "scripts/old_file.R"
+
+git_state: {}
+
+request:
+  method: POST
+  path: "/api/issues/1/rename"
+  body:
+    new_path: "   "
+
+response:
+  status: 400

--- a/src/api/tests/cases/issues/rename_issue_not_found.yaml
+++ b/src/api/tests/cases/issues/rename_issue_not_found.yaml
@@ -1,0 +1,13 @@
+name: "POST /api/issues/{number}/rename - issue not found"
+description: "Rename a non-existent issue returns an error (502 from mock, 404 from real GitHub)"
+
+git_state: {}
+
+request:
+  method: POST
+  path: "/api/issues/999/rename"
+  body:
+    new_path: "scripts/new_file.R"
+
+response:
+  status: 502

--- a/src/api/tests/cases/issues/rename_issue_success.yaml
+++ b/src/api/tests/cases/issues/rename_issue_success.yaml
@@ -1,0 +1,31 @@
+name: "POST /api/issues/{number}/rename - success"
+description: "Rename an issue by updating its title and body"
+
+fixtures:
+  issues:
+    - type: mock
+      number: 1
+      title: "scripts/old_file.R"
+      body: |
+        ## Metadata
+        initial qc commit: abc1234567890abcdef1234567890abcdef12340
+        git branch: main
+        author: Test User
+
+git_state: {}
+
+request:
+  method: POST
+  path: "/api/issues/1/rename"
+  body:
+    new_path: "scripts/new_file.R"
+
+response:
+  status: 204
+
+assert_write_calls:
+  - type: UpdateIssue
+    issue_number: 1
+    new_title: "scripts/new_file.R"
+  - type: PostComment
+    comment_type: "ghqctoolkit::api::routes::issues::RenameComment"

--- a/src/api/tests/cases/milestones/list_milestone_renames_empty.yaml
+++ b/src/api/tests/cases/milestones/list_milestone_renames_empty.yaml
@@ -1,0 +1,25 @@
+name: "GET /api/milestones/{number}/renames - no renames detected"
+description: "Returns empty array when no renames are detected (mock git has no real renames)"
+
+fixtures:
+  milestones:
+    - type: mock
+      number: 1
+      title: v1.0
+  issues:
+    - type: mock
+      number: 1
+      title: "scripts/file.R"
+      milestone: 1
+
+git_state: {}
+
+request:
+  method: GET
+  path: "/api/milestones/1/renames"
+
+response:
+  status: 200
+  body:
+    match_type: exact
+    value: []

--- a/src/api/tests/cases/milestones/list_milestone_renames_not_found.yaml
+++ b/src/api/tests/cases/milestones/list_milestone_renames_not_found.yaml
@@ -1,0 +1,14 @@
+name: "GET /api/milestones/{number}/renames - milestone not found"
+description: "Returns empty array when milestone does not exist (no issues are found for it)"
+
+git_state: {}
+
+request:
+  method: GET
+  path: "/api/milestones/999/renames"
+
+response:
+  status: 200
+  body:
+    match_type: exact
+    value: []

--- a/src/api/tests/harness/runner.rs
+++ b/src/api/tests/harness/runner.rs
@@ -220,6 +220,17 @@ fn validate_write_calls(
             ExpectedWriteCall::StashFile { file, position } => {
                 (WriteCall::StashFile { file: file.clone() }, position)
             }
+            ExpectedWriteCall::UpdateIssue {
+                issue_number,
+                new_title,
+                position,
+            } => (
+                WriteCall::UpdateIssue {
+                    issue_number: *issue_number,
+                    new_title: new_title.clone(),
+                },
+                position,
+            ),
         };
 
         // Check if call exists

--- a/src/api/tests/harness/types.rs
+++ b/src/api/tests/harness/types.rs
@@ -320,6 +320,13 @@ pub enum ExpectedWriteCall {
         #[serde(default)]
         position: Option<CallPosition>,
     },
+    UpdateIssue {
+        issue_number: u64,
+        #[serde(default)]
+        new_title: Option<String>,
+        #[serde(default)]
+        position: Option<CallPosition>,
+    },
 }
 
 /// Position assertion for write calls

--- a/src/api/tests/helpers.rs
+++ b/src/api/tests/helpers.rs
@@ -35,6 +35,10 @@ pub enum WriteCall {
     StashFile {
         file: String,
     },
+    UpdateIssue {
+        issue_number: u64,
+        new_title: Option<String>,
+    },
 }
 
 /// Mock implementation of all git traits for testing.
@@ -622,6 +626,31 @@ impl GitHubWriter for MockGitInfo {
             .lock()
             .unwrap()
             .push(WriteCall::OpenIssue { issue_number });
+        Ok(())
+    }
+
+    async fn update_issue(
+        &self,
+        issue_number: u64,
+        new_title: Option<String>,
+        new_body: Option<String>,
+    ) -> Result<(), GitHubApiError> {
+        self.write_calls
+            .lock()
+            .unwrap()
+            .push(WriteCall::UpdateIssue {
+                issue_number,
+                new_title: new_title.clone(),
+            });
+        // Also update the issue in the mock store so subsequent reads see the new title
+        if let Some(title) = new_title {
+            if let Ok(mut issues) = self.issues.lock() {
+                if let Some(issue) = issues.get_mut(&issue_number) {
+                    issue.title = title;
+                }
+            }
+        }
+        let _ = new_body; // body update tracked via write call only
         Ok(())
     }
 

--- a/src/api/types/responses.rs
+++ b/src/api/types/responses.rs
@@ -9,8 +9,9 @@ use octocrab::models::IssueState;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    GitHubApiError, GitProvider, IssueThread, ReviewStashResult, analyze_issue_checklists,
-    api::ApiError, create::CreateResult, get_git_status, parse_blocking_qcs,
+    FileRenameEvent, GitHubApiError, GitProvider, IssueThread, ReviewStashResult,
+    analyze_issue_checklists, api::ApiError, create::CreateResult, get_git_status,
+    parse_blocking_qcs, parse_file_history,
 };
 
 /// Health check response.
@@ -65,6 +66,14 @@ pub struct RelevantFileInfo {
     pub issue_url: Option<String>,
 }
 
+/// A detected rename of a file that has an open QC issue.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DetectedRename {
+    pub issue_number: u64,
+    pub old_path: String,
+    pub new_path: String,
+}
+
 /// Issue information.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Issue {
@@ -82,6 +91,7 @@ pub struct Issue {
     pub branch: Option<String>,
     pub checklist_name: Option<String>,
     pub relevant_files: Vec<RelevantFileInfo>,
+    pub file_history: Vec<FileRenameEvent>,
 }
 
 impl From<octocrab::models::issues::Issue> for Issue {
@@ -112,6 +122,11 @@ impl From<octocrab::models::issues::Issue> for Issue {
                 .body
                 .as_deref()
                 .map(parse_relevant_file_infos)
+                .unwrap_or_default(),
+            file_history: issue
+                .body
+                .as_deref()
+                .map(parse_file_history)
                 .unwrap_or_default(),
         }
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -37,8 +37,8 @@ pub use interactive::{
     prompt_existing_milestone, prompt_file, prompt_issue, prompt_milestone,
     prompt_milestone_archive, prompt_milestone_record,
 };
-pub use sitrep::SitRep;
 pub use rename::{confirm_rename_noninteractive, interactive_rename};
+pub use sitrep::SitRep;
 pub use status::{
     interactive_milestone_status, interactive_status, milestone_status, single_issue_status,
 };

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,7 @@ mod auth;
 mod context;
 mod file_parser;
 mod interactive;
+pub mod rename;
 mod sitrep;
 mod status;
 
@@ -37,6 +38,7 @@ pub use interactive::{
     prompt_milestone_archive, prompt_milestone_record,
 };
 pub use sitrep::SitRep;
+pub use rename::{confirm_rename_noninteractive, interactive_rename};
 pub use status::{
     interactive_milestone_status, interactive_status, milestone_status, single_issue_status,
 };

--- a/src/cli/rename.rs
+++ b/src/cli/rename.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use inquire::Confirm;
-use octocrab::models::issues::Issue;
 use octocrab::models::Milestone;
+use octocrab::models::issues::Issue;
 use std::path::PathBuf;
 
 use crate::cli::interactive::prompt_existing_milestone;
@@ -73,7 +73,10 @@ pub async fn alert_renames<G: GitProvider + 'static>(
     println!();
     println!("⚠️  Detected {} file rename(s):", renames.len());
     for (old_path, new_path) in &renames {
-        if let Some(issue) = open_issues.iter().find(|i| PathBuf::from(&i.title) == *old_path) {
+        if let Some(issue) = open_issues
+            .iter()
+            .find(|i| PathBuf::from(&i.title) == *old_path)
+        {
             println!(
                 "  `{}` → `{}` (issue #{})",
                 old_path.display(),
@@ -129,7 +132,10 @@ pub async fn interactive_rename<G: GitProvider + 'static>(
     .await?;
 
     if renames.is_empty() {
-        println!("No file renames detected for open issues in '{}'.", milestone.title);
+        println!(
+            "No file renames detected for open issues in '{}'.",
+            milestone.title
+        );
         return Ok(());
     }
 
@@ -189,10 +195,8 @@ pub async fn confirm_rename_noninteractive<G: GitProvider + 'static>(
 ) -> Result<()> {
     let repo_path = git_info.path().to_path_buf();
     let old_path_clone = old_path.clone();
-    let renames = tokio::task::spawn_blocking(move || {
-        detect_renames(&repo_path, &[old_path_clone])
-    })
-    .await?;
+    let renames =
+        tokio::task::spawn_blocking(move || detect_renames(&repo_path, &[old_path_clone])).await?;
 
     let new_path = renames
         .into_iter()
@@ -234,7 +238,11 @@ async fn confirm_rename<G: GitProvider>(
     let new_body = splice_file_history(&current_body, &history_section);
 
     git_info
-        .update_issue(raw_issue.number as u64, Some(new_path_str.clone()), Some(new_body))
+        .update_issue(
+            raw_issue.number as u64,
+            Some(new_path_str.clone()),
+            Some(new_body),
+        )
         .await?;
 
     log::info!(

--- a/src/cli/rename.rs
+++ b/src/cli/rename.rs
@@ -1,0 +1,262 @@
+use anyhow::Result;
+use inquire::Confirm;
+use octocrab::models::issues::Issue;
+use octocrab::models::Milestone;
+use std::path::PathBuf;
+
+use crate::cli::interactive::prompt_existing_milestone;
+use crate::comment_system::CommentBody;
+use crate::git::{GitFileOps, GitHelpers, GitHubApiError};
+use crate::{
+    FileRenameEvent, GitProvider, detect_renames, file_history_section, head_commit_hash,
+    parse_file_history, splice_file_history,
+};
+
+/// CommentBody for posting a rename confirmation to the issue timeline.
+struct RenameComment {
+    issue: Issue,
+    old_path: String,
+    new_path: String,
+    commit: String,
+}
+
+impl CommentBody for RenameComment {
+    fn generate_body(&self, _git_info: &(impl GitHelpers + GitFileOps)) -> String {
+        format!(
+            "# QC File Rename\n`{}` \u{2192} `{}` (commit: {})",
+            self.old_path, self.new_path, self.commit
+        )
+    }
+
+    fn issue(&self) -> &Issue {
+        &self.issue
+    }
+
+    fn title(&self) -> &str {
+        "QC File Rename"
+    }
+}
+
+/// Alert-only: detect renamed files across the given issues and print a warning
+/// if any are found, directing the user to run `ghqc issue rename`.
+/// Returns the number of detected renames (without confirming any).
+pub async fn alert_renames<G: GitProvider + 'static>(
+    git_info: &G,
+    issues: &[Issue],
+) -> Result<usize> {
+    let repo_path = git_info.path().to_path_buf();
+
+    let open_issues: Vec<&Issue> = issues
+        .iter()
+        .filter(|i| matches!(i.state, octocrab::models::IssueState::Open))
+        .collect();
+
+    if open_issues.is_empty() {
+        return Ok(0);
+    }
+
+    let issue_paths: Vec<PathBuf> = open_issues
+        .iter()
+        .map(|i| PathBuf::from(&i.title))
+        .collect();
+
+    let renames = tokio::task::spawn_blocking({
+        let repo_path = repo_path.clone();
+        move || detect_renames(&repo_path, &issue_paths)
+    })
+    .await?;
+
+    if renames.is_empty() {
+        return Ok(0);
+    }
+
+    println!();
+    println!("⚠️  Detected {} file rename(s):", renames.len());
+    for (old_path, new_path) in &renames {
+        if let Some(issue) = open_issues.iter().find(|i| PathBuf::from(&i.title) == *old_path) {
+            println!(
+                "  `{}` → `{}` (issue #{})",
+                old_path.display(),
+                new_path.display(),
+                issue.number
+            );
+        }
+    }
+    println!("  Run `ghqc issue rename` to confirm.");
+
+    Ok(renames.len())
+}
+
+/// Interactive rename command: prompt for a milestone, detect renames, and
+/// confirm each one interactively. Returns the number of renames confirmed.
+pub async fn interactive_rename<G: GitProvider + 'static>(
+    milestones: &[Milestone],
+    git_info: &G,
+) -> Result<()> {
+    let milestone = if milestones.len() == 1 {
+        milestones[0].clone()
+    } else {
+        prompt_existing_milestone(milestones)?
+    };
+
+    let issues = git_info.get_issues(Some(milestone.number as u64)).await?;
+    if issues.is_empty() {
+        println!("No issues found in milestone '{}'.", milestone.title);
+        return Ok(());
+    }
+
+    let repo_path = git_info.path().to_path_buf();
+
+    let open_issues: Vec<&Issue> = issues
+        .iter()
+        .filter(|i| matches!(i.state, octocrab::models::IssueState::Open))
+        .collect();
+
+    if open_issues.is_empty() {
+        println!("No open issues found in milestone '{}'.", milestone.title);
+        return Ok(());
+    }
+
+    let issue_paths: Vec<PathBuf> = open_issues
+        .iter()
+        .map(|i| PathBuf::from(&i.title))
+        .collect();
+
+    let renames = tokio::task::spawn_blocking({
+        let repo_path = repo_path.clone();
+        move || detect_renames(&repo_path, &issue_paths)
+    })
+    .await?;
+
+    if renames.is_empty() {
+        println!("No file renames detected for open issues in '{}'.", milestone.title);
+        return Ok(());
+    }
+
+    println!();
+    println!("⚠️  Detected {} file rename(s):", renames.len());
+
+    let mut confirmed = 0;
+    for (old_path, new_path) in &renames {
+        let issue = match open_issues
+            .iter()
+            .find(|i| PathBuf::from(&i.title) == *old_path)
+        {
+            Some(i) => *i,
+            None => continue,
+        };
+
+        println!(
+            "  `{}` → `{}` (issue #{})",
+            old_path.display(),
+            new_path.display(),
+            issue.number
+        );
+
+        let answer = Confirm::new(&format!(
+            "Update issue #{} title and record rename in body?",
+            issue.number
+        ))
+        .with_default(true)
+        .prompt()?;
+
+        if !answer {
+            println!("  Skipped.");
+            continue;
+        }
+
+        if let Err(e) = confirm_rename(git_info, issue, old_path, new_path, &repo_path).await {
+            eprintln!("  ✗ Failed to confirm rename: {e}");
+        } else {
+            println!("  ✓ Issue #{} updated.", issue.number);
+            confirmed += 1;
+        }
+    }
+
+    if confirmed > 0 {
+        println!();
+        println!("✅ Confirmed {confirmed} rename(s).");
+    }
+
+    Ok(())
+}
+
+/// Non-interactive rename: auto-detect where `old_path` was renamed to and confirm without prompting.
+pub async fn confirm_rename_noninteractive<G: GitProvider + 'static>(
+    git_info: &G,
+    raw_issue: &Issue,
+    old_path: &PathBuf,
+) -> Result<()> {
+    let repo_path = git_info.path().to_path_buf();
+    let old_path_clone = old_path.clone();
+    let renames = tokio::task::spawn_blocking(move || {
+        detect_renames(&repo_path, &[old_path_clone])
+    })
+    .await?;
+
+    let new_path = renames
+        .into_iter()
+        .find(|(old, _)| old == old_path)
+        .map(|(_, new)| new)
+        .ok_or_else(|| anyhow::anyhow!("No rename detected for '{}'", old_path.display()))?;
+
+    let repo_path = git_info.path().to_path_buf();
+    confirm_rename(git_info, raw_issue, old_path, &new_path, &repo_path)
+        .await
+        .map_err(anyhow::Error::from)
+}
+
+async fn confirm_rename<G: GitProvider>(
+    git_info: &G,
+    raw_issue: &Issue,
+    old_path: &PathBuf,
+    new_path: &PathBuf,
+    repo_path: &std::path::Path,
+) -> Result<(), GitHubApiError> {
+    let old_path_str = old_path.to_string_lossy().to_string();
+    let new_path_str = new_path.to_string_lossy().to_string();
+    let current_body = raw_issue.body.as_deref().unwrap_or("").to_string();
+
+    let repo_path = repo_path.to_path_buf();
+    let commit_hash = tokio::task::spawn_blocking(move || {
+        head_commit_hash(&repo_path).unwrap_or_else(|| "unknown".to_string())
+    })
+    .await
+    .unwrap_or_else(|_| "unknown".to_string());
+
+    let mut events = parse_file_history(&current_body);
+    events.push(FileRenameEvent {
+        old_path: old_path_str.clone(),
+        new_path: new_path_str.clone(),
+        commit: commit_hash.clone(),
+    });
+    let history_section = file_history_section(&events);
+    let new_body = splice_file_history(&current_body, &history_section);
+
+    git_info
+        .update_issue(raw_issue.number as u64, Some(new_path_str.clone()), Some(new_body))
+        .await?;
+
+    log::info!(
+        "Renamed issue #{}: {:?} → {:?} (commit {})",
+        raw_issue.number,
+        old_path_str,
+        new_path_str,
+        commit_hash
+    );
+
+    let comment = RenameComment {
+        issue: raw_issue.clone(),
+        old_path: old_path_str,
+        new_path: new_path_str,
+        commit: commit_hash,
+    };
+    if let Err(e) = git_info.post_comment(&comment).await {
+        log::warn!(
+            "Failed to post rename comment to issue #{}: {e}",
+            raw_issue.number
+        );
+    }
+
+    Ok(())
+}

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -5,6 +5,7 @@ use gix::ObjectId;
 use octocrab::models::Milestone;
 
 use crate::cli::interactive::{prompt_existing_milestone, prompt_issue};
+use crate::cli::rename::alert_renames;
 use crate::{
     BlockingQCStatus, ChecklistSummary, DiskCache, GitHubReader, GitInfo, GitState, IssueThread,
     QCStatus, analyze_issue_checklists, get_blocking_qc_status, get_git_status,
@@ -31,6 +32,9 @@ pub async fn interactive_status(
     if issues.is_empty() {
         bail!("No issues found in milestone '{}'", milestone.title);
     }
+
+    // Alert about any pending file renames (run `ghqc issue rename` to confirm).
+    alert_renames(git_info, &issues).await?;
 
     // Select issue by title
     let issue = prompt_issue(&issues)?;
@@ -284,6 +288,9 @@ async fn get_milestone_status_rows(
     for milestone in milestones {
         // Get all issues for this milestone
         let issues = git_info.get_issues(Some(milestone.number as u64)).await?;
+
+        // Alert about any pending file renames (run `ghqc issue rename` to confirm).
+        alert_renames(git_info, &issues).await?;
 
         for issue in issues {
             // Create IssueThread for each issue

--- a/src/create.rs
+++ b/src/create.rs
@@ -1300,6 +1300,15 @@ mod tests {
                 }
             }
         }
+
+        fn update_issue(
+            &self,
+            _issue_number: u64,
+            _new_title: Option<String>,
+            _new_body: Option<String>,
+        ) -> impl std::future::Future<Output = Result<(), GitHubApiError>> + Send {
+            async move { Err(GitHubApiError::NoApi) }
+        }
     }
 
     impl GitHubReader for MockGitInfo {

--- a/src/git/api/write.rs
+++ b/src/git/api/write.rs
@@ -54,6 +54,16 @@ pub trait GitHubWriter {
         blocked_issue_number: u64,
         blocking_issue_id: u64,
     ) -> impl Future<Output = Result<(), GitHubApiError>> + Send;
+
+    /// Update an issue's title and/or body via PATCH.
+    ///
+    /// Pass `None` for fields that should not change.
+    fn update_issue(
+        &self,
+        issue_number: u64,
+        new_title: Option<String>,
+        new_body: Option<String>,
+    ) -> impl Future<Output = Result<(), GitHubApiError>> + Send;
 }
 
 impl GitHubWriter for GitInfo {
@@ -376,6 +386,57 @@ impl GitHubWriter for GitInfo {
                 "Successfully created blocking relationship: issue #{} is now blocked by issue ID {}",
                 blocked_issue_number,
                 blocking_issue_id
+            );
+
+            Ok(())
+        }
+    }
+
+    fn update_issue(
+        &self,
+        issue_number: u64,
+        new_title: Option<String>,
+        new_body: Option<String>,
+    ) -> impl Future<Output = Result<(), GitHubApiError>> + Send {
+        let owner = self.owner.clone();
+        let repo = self.repo.clone();
+        let base_url = self.base_url.clone();
+        let auth_sources = self.auth_sources.clone();
+
+        async move {
+            let octocrab = auth_sources
+                .client(&base_url)
+                .map_err(GitHubApiError::ClientCreation)?;
+
+            log::debug!(
+                "Updating issue #{} in {}/{} (title: {:?})",
+                issue_number,
+                owner,
+                repo,
+                new_title
+            );
+
+            let mut patch = serde_json::json!({});
+            if let Some(title) = new_title {
+                patch["title"] = serde_json::Value::String(title);
+            }
+            if let Some(body) = new_body {
+                patch["body"] = serde_json::Value::String(body);
+            }
+
+            let _: serde_json::Value = octocrab
+                .patch(
+                    format!("/repos/{}/{}/issues/{}", &owner, &repo, issue_number),
+                    Some(&patch),
+                )
+                .await
+                .map_err(GitHubApiError::APIError)?;
+
+            log::debug!(
+                "Successfully updated issue #{} in {}/{}",
+                issue_number,
+                owner,
+                repo
             );
 
             Ok(())

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -27,7 +27,10 @@ pub use file_ops::MockGitFileOps;
 pub use helpers::GitHelpers;
 pub use provider::GitProvider;
 pub use repository::{FileStashOutcome, GitRepository, GitRepositoryError};
-pub use status::{GitState, GitStatus, GitStatusError, GitStatusOps, get_git_status};
+pub use status::{
+    GitState, GitStatus, GitStatusError, GitStatusOps, detect_renames, get_git_status,
+    head_commit_hash,
+};
 
 use crate::auth::AuthStore;
 use crate::utils::EnvProvider;

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -349,7 +349,11 @@ fn is_file_tracked(repo_path: &std::path::Path, file: &std::path::Path) -> bool 
     match output {
         Ok(o) => o.status.success(),
         Err(e) => {
-            log::warn!("[rename] is_file_tracked {:?}: failed to spawn git: {}", file, e);
+            log::warn!(
+                "[rename] is_file_tracked {:?}: failed to spawn git: {}",
+                file,
+                e
+            );
             false
         }
     }
@@ -384,11 +388,16 @@ fn find_rename_target(repo_path: &std::path::Path, old_path: &std::path::Path) -
         .ok()?;
 
     if !commit_output.status.success() {
-        log::warn!("[rename] find_rename_target {:?}: git log -1 failed", old_path);
+        log::warn!(
+            "[rename] find_rename_target {:?}: git log -1 failed",
+            old_path
+        );
         return None;
     }
 
-    let commit_hash = String::from_utf8_lossy(&commit_output.stdout).trim().to_string();
+    let commit_hash = String::from_utf8_lossy(&commit_output.stdout)
+        .trim()
+        .to_string();
     if commit_hash.is_empty() {
         return None;
     }
@@ -407,7 +416,11 @@ fn find_rename_target(repo_path: &std::path::Path, old_path: &std::path::Path) -
         .ok()?;
 
     if !show_output.status.success() {
-        log::warn!("[rename] find_rename_target {:?}: git show {} failed", old_path, commit_hash);
+        log::warn!(
+            "[rename] find_rename_target {:?}: git show {} failed",
+            old_path,
+            commit_hash
+        );
         return None;
     }
 
@@ -422,7 +435,7 @@ fn find_rename_target(repo_path: &std::path::Path, old_path: &std::path::Path) -
         if parts.len() == 3 && PathBuf::from(parts[1]) == old_path {
             let new_path = PathBuf::from(parts[2]);
             if is_file_tracked(repo_path, &new_path) {
-                log::info!("[rename] {:?} → {:?}", old_path, new_path);
+                log::debug!("[rename] {:?} → {:?}", old_path, new_path);
                 return Some(new_path);
             }
         }
@@ -437,7 +450,10 @@ fn find_rename_target(repo_path: &std::path::Path, old_path: &std::path::Path) -
 /// Returns one `FileRenameEvent` (without commit hash) per detected rename.
 /// The commit hash field is left empty here — callers that need it should fetch
 /// it separately, or it will be populated when the rename is confirmed.
-pub fn detect_renames(repo_path: &std::path::Path, issue_paths: &[PathBuf]) -> Vec<(PathBuf, PathBuf)> {
+pub fn detect_renames(
+    repo_path: &std::path::Path,
+    issue_paths: &[PathBuf],
+) -> Vec<(PathBuf, PathBuf)> {
     let mut renames = Vec::new();
     for old_path in issue_paths {
         if is_file_tracked(repo_path, old_path) {
@@ -453,7 +469,13 @@ pub fn detect_renames(repo_path: &std::path::Path, issue_paths: &[PathBuf]) -> V
 /// Get the short (8-char) HEAD commit hash for the given repo path.
 pub fn head_commit_hash(repo_path: &std::path::Path) -> Option<String> {
     let output = std::process::Command::new("git")
-        .args(["-C", &repo_path.to_string_lossy(), "rev-parse", "--short", "HEAD"])
+        .args([
+            "-C",
+            &repo_path.to_string_lossy(),
+            "rev-parse",
+            "--short",
+            "HEAD",
+        ])
         .output()
         .ok()?;
     if output.status.success() {

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -333,6 +333,136 @@ impl GitStatusOps for GitInfo {
     }
 }
 
+/// Check whether a file path is tracked in the current git index of `repo_path`.
+///
+/// Uses `git ls-files <path>` — empty stdout means the file is untracked/deleted.
+fn is_file_tracked(repo_path: &std::path::Path, file: &std::path::Path) -> bool {
+    let output = std::process::Command::new("git")
+        .args([
+            "-C",
+            &repo_path.to_string_lossy(),
+            "ls-files",
+            "--error-unmatch",
+            &file.to_string_lossy(),
+        ])
+        .output();
+    match output {
+        Ok(o) => o.status.success(),
+        Err(e) => {
+            log::warn!("[rename] is_file_tracked {:?}: failed to spawn git: {}", file, e);
+            false
+        }
+    }
+}
+
+/// Find the most recent rename destination for `old_path` using git log with
+/// `--follow --diff-filter=R`.
+///
+/// Returns `Some(new_path)` if git can detect a rename, `None` otherwise.
+fn find_rename_target(repo_path: &std::path::Path, old_path: &std::path::Path) -> Option<PathBuf> {
+    // git log --follow --diff-filter=R --name-status --format="" HEAD -- <old_path>
+    // Outputs lines like: R100\told_name\tnew_name  (with blank lines between entries)
+    // Strategy: combining --diff-filter=R with a pathspec only matches when the path is the
+    // *destination* of a rename, not the source. Instead we do it in two steps:
+    //   1. Find the most recent commit that touched old_path (the rename commit).
+    //   2. Inspect that specific commit for R-type diffs and look for old_path as the source.
+    // Strategy: combining --diff-filter=R with a pathspec only matches when the path is the
+    // *destination* of a rename, not the source. Instead we do it in two steps:
+    //   1. Find the most recent commit that touched old_path (the rename commit).
+    //   2. Inspect that specific commit for R-type diffs and look for old_path as the source.
+    let commit_output = std::process::Command::new("git")
+        .args([
+            "-C",
+            &repo_path.to_string_lossy(),
+            "log",
+            "-1",
+            "--format=%H",
+            "--",
+            &old_path.to_string_lossy(),
+        ])
+        .output()
+        .ok()?;
+
+    if !commit_output.status.success() {
+        log::warn!("[rename] find_rename_target {:?}: git log -1 failed", old_path);
+        return None;
+    }
+
+    let commit_hash = String::from_utf8_lossy(&commit_output.stdout).trim().to_string();
+    if commit_hash.is_empty() {
+        return None;
+    }
+
+    let show_output = std::process::Command::new("git")
+        .args([
+            "-C",
+            &repo_path.to_string_lossy(),
+            "show",
+            "--diff-filter=R",
+            "--name-status",
+            "--format=",
+            &commit_hash,
+        ])
+        .output()
+        .ok()?;
+
+    if !show_output.status.success() {
+        log::warn!("[rename] find_rename_target {:?}: git show {} failed", old_path, commit_hash);
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&show_output.stdout);
+    for line in stdout.lines() {
+        let line = line.trim();
+        if !line.starts_with('R') {
+            continue;
+        }
+        // Tab-separated: R<score>\t<old>\t<new>
+        let parts: Vec<&str> = line.splitn(3, '\t').collect();
+        if parts.len() == 3 && PathBuf::from(parts[1]) == old_path {
+            let new_path = PathBuf::from(parts[2]);
+            if is_file_tracked(repo_path, &new_path) {
+                log::info!("[rename] {:?} → {:?}", old_path, new_path);
+                return Some(new_path);
+            }
+        }
+    }
+
+    None
+}
+
+/// For each path in `issue_paths` that no longer exists in the git index, attempt
+/// to find a rename using `git log --follow --diff-filter=R`.
+///
+/// Returns one `FileRenameEvent` (without commit hash) per detected rename.
+/// The commit hash field is left empty here — callers that need it should fetch
+/// it separately, or it will be populated when the rename is confirmed.
+pub fn detect_renames(repo_path: &std::path::Path, issue_paths: &[PathBuf]) -> Vec<(PathBuf, PathBuf)> {
+    let mut renames = Vec::new();
+    for old_path in issue_paths {
+        if is_file_tracked(repo_path, old_path) {
+            continue; // file still exists — no rename needed
+        }
+        if let Some(new_path) = find_rename_target(repo_path, old_path) {
+            renames.push((old_path.clone(), new_path));
+        }
+    }
+    renames
+}
+
+/// Get the short (8-char) HEAD commit hash for the given repo path.
+pub fn head_commit_hash(repo_path: &std::path::Path) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["-C", &repo_path.to_string_lossy(), "rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()?;
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        None
+    }
+}
+
 /// Fetch from remote and then get repository status
 ///
 /// This function ensures the status check is performed against the actual remote state,

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -1768,4 +1768,167 @@ author: test"#;
         let result = determine_relationship_from_body(body, 123);
         assert_eq!(result, BlockingRelationship::Unknown);
     }
+
+    // ── parse_file_history ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_file_history_no_section() {
+        let body = "## Metadata\nsome content\n";
+        let events = parse_file_history(body);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_parse_file_history_single_event() {
+        let body = "## File History\n* `old/path.R` → `new/path.R` (commit: abc1234)\n";
+        let events = parse_file_history(body);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].old_path, "old/path.R");
+        assert_eq!(events[0].new_path, "new/path.R");
+        assert_eq!(events[0].commit, "abc1234");
+    }
+
+    #[test]
+    fn test_parse_file_history_multiple_events() {
+        let body = "## File History\n\
+            * `a.R` → `b.R` (commit: 111aaaa)\n\
+            * `b.R` → `c.R` (commit: 222bbbb)\n";
+        let events = parse_file_history(body);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].old_path, "a.R");
+        assert_eq!(events[0].new_path, "b.R");
+        assert_eq!(events[0].commit, "111aaaa");
+        assert_eq!(events[1].old_path, "b.R");
+        assert_eq!(events[1].new_path, "c.R");
+        assert_eq!(events[1].commit, "222bbbb");
+    }
+
+    #[test]
+    fn test_parse_file_history_malformed_lines_skipped() {
+        let body = "## File History\n\
+            * `good.R` → `better.R` (commit: abc0001)\n\
+            * malformed line without backticks\n\
+            * `missing_arrow.R` something wrong\n\
+            * `also_good.R` → `also_better.R` (commit: abc0002)\n";
+        let events = parse_file_history(body);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].old_path, "good.R");
+        assert_eq!(events[1].old_path, "also_good.R");
+    }
+
+    #[test]
+    fn test_parse_file_history_terminates_at_next_section() {
+        let body = "## File History\n\
+            * `old.R` → `new.R` (commit: abc1234)\n\
+            ## Other Section\n\
+            * `should_not.R` → `be_parsed.R` (commit: 000000)\n";
+        let events = parse_file_history(body);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].old_path, "old.R");
+    }
+
+    // ── file_history_section ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_file_history_section_empty_slice() {
+        let section = file_history_section(&[]);
+        assert_eq!(section, "## File History\n");
+    }
+
+    #[test]
+    fn test_file_history_section_single_event() {
+        let events = vec![FileRenameEvent {
+            old_path: "src/old.R".to_string(),
+            new_path: "src/new.R".to_string(),
+            commit: "deadbeef".to_string(),
+        }];
+        let section = file_history_section(&events);
+        assert_eq!(section, "## File History\n* `src/old.R` → `src/new.R` (commit: deadbeef)\n");
+    }
+
+    #[test]
+    fn test_file_history_section_multiple_events() {
+        let events = vec![
+            FileRenameEvent {
+                old_path: "a.R".to_string(),
+                new_path: "b.R".to_string(),
+                commit: "aaa1111".to_string(),
+            },
+            FileRenameEvent {
+                old_path: "b.R".to_string(),
+                new_path: "c.R".to_string(),
+                commit: "bbb2222".to_string(),
+            },
+        ];
+        let section = file_history_section(&events);
+        assert!(section.starts_with("## File History\n"));
+        assert!(section.contains("* `a.R` → `b.R` (commit: aaa1111)\n"));
+        assert!(section.contains("* `b.R` → `c.R` (commit: bbb2222)\n"));
+    }
+
+    // ── find_checklist_start ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_find_checklist_start_finds_h1() {
+        let body = "## Metadata\nsome text\n# Checklist\n- item\n";
+        let pos = find_checklist_start(body);
+        assert!(pos.is_some());
+        let offset = pos.unwrap();
+        assert!(body[offset..].starts_with("# Checklist"));
+    }
+
+    #[test]
+    fn test_find_checklist_start_only_h2_returns_none() {
+        let body = "## Metadata\n## File History\n## Another\n";
+        let pos = find_checklist_start(body);
+        assert!(pos.is_none());
+    }
+
+    #[test]
+    fn test_find_checklist_start_empty_body() {
+        let pos = find_checklist_start("");
+        assert!(pos.is_none());
+    }
+
+    // ── splice_file_history ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_splice_file_history_no_section_with_checklist() {
+        let body = "## Metadata\nsome text\n\n# Checklist\n- [ ] item\n";
+        let history = "## File History\n* `old.R` → `new.R` (commit: abc)\n";
+        let result = splice_file_history(body, history);
+        // History must appear before the checklist
+        let history_pos = result.find("## File History").expect("history missing");
+        let checklist_pos = result.find("# Checklist").expect("checklist missing");
+        assert!(history_pos < checklist_pos);
+    }
+
+    #[test]
+    fn test_splice_file_history_no_section_no_checklist() {
+        let body = "## Metadata\nsome text\n";
+        let history = "## File History\n* `old.R` → `new.R` (commit: abc)\n";
+        let result = splice_file_history(body, history);
+        // History appended at end
+        assert!(result.contains("## File History"));
+        assert!(result.ends_with("## File History\n* `old.R` → `new.R` (commit: abc)"));
+    }
+
+    #[test]
+    fn test_splice_file_history_replaces_existing_section() {
+        let body = "## Metadata\nsome text\n\n## File History\n* `old.R` → `mid.R` (commit: 111)\n\n# Checklist\n- [ ] item\n";
+        let new_history = "## File History\n* `old.R` → `mid.R` (commit: 111)\n* `mid.R` → `new.R` (commit: 222)\n";
+        let result = splice_file_history(body, new_history);
+        // Only one File History section
+        assert_eq!(result.matches("## File History").count(), 1);
+        assert!(result.contains("commit: 222"));
+    }
+
+    #[test]
+    fn test_splice_file_history_existing_section_at_end() {
+        let body = "## Metadata\nsome text\n\n## File History\n* `old.R` → `new.R` (commit: abc)\n";
+        let new_history = "## File History\n* `old.R` → `new.R` (commit: abc)\n* `new.R` → `newest.R` (commit: def)\n";
+        let result = splice_file_history(body, new_history);
+        assert_eq!(result.matches("## File History").count(), 1);
+        assert!(result.contains("commit: def"));
+    }
 }

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -602,6 +602,49 @@ pub fn parse_file_history(body: &str) -> Vec<FileRenameEvent> {
     events
 }
 
+/// Insert (or replace) the `## File History` section in the issue body.
+///
+/// If the section already exists it is replaced in-place.
+/// Otherwise it is inserted immediately before the first `# ` checklist heading,
+/// or appended at the end if no such heading exists.
+pub fn splice_file_history(body: &str, history_section: &str) -> String {
+    let history_trimmed = history_section.trim_end();
+
+    if let Some(start) = body.find("## File History") {
+        let before = body[..start].trim_end();
+        let after_header = &body[start + "## File History".len()..];
+        let after = match after_header.find("\n## ") {
+            Some(p) => &after_header[p + 1..],
+            None => "",
+        };
+        return if after.is_empty() {
+            format!("{}\n{}", before, history_trimmed)
+        } else {
+            format!("{}\n{}\n\n{}", before, history_trimmed, after)
+        };
+    }
+
+    if let Some(checklist_pos) = find_checklist_start(body) {
+        let before = body[..checklist_pos].trim_end();
+        let rest = &body[checklist_pos..];
+        format!("{}\n\n{}\n\n{}", before, history_trimmed, rest)
+    } else {
+        format!("{}\n\n{}", body.trim_end(), history_trimmed)
+    }
+}
+
+/// Find the byte offset of the first `# ` heading that is NOT `## `.
+pub fn find_checklist_start(body: &str) -> Option<usize> {
+    let mut pos = 0usize;
+    for line in body.lines() {
+        if line.starts_with("# ") && !line.starts_with("## ") {
+            return Some(pos);
+        }
+        pos += line.len() + 1;
+    }
+    None
+}
+
 /// Generate the markdown for a "## File History" section.
 pub fn file_history_section(events: &[FileRenameEvent]) -> String {
     let mut section = String::from("## File History\n");

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -171,7 +171,7 @@ impl IssueThread {
 
         // Pre-compute which commits touch this issue's file (one subprocess call).
         let commit_hashes: Vec<String> = all_commits.iter().map(|c| c.commit.to_string()).collect();
-        let file_touching = find_or_cache_file_changes(
+        let mut file_touching = find_or_cache_file_changes(
             &commit_hashes,
             git_info,
             Some(branch.clone()),
@@ -179,6 +179,30 @@ impl IssueThread {
             disk_cache,
         )
         .map_err(IssueError::GitFileOpsError)?;
+
+        // Also mark commits that touched any previously-known file names from ## File History.
+        // This ensures commits made against the old filename are still flagged as file-changing.
+        let old_paths: Vec<PathBuf> = issue
+            .body
+            .as_deref()
+            .map(|body| {
+                parse_file_history(body)
+                    .into_iter()
+                    .map(|e| PathBuf::from(e.old_path))
+                    .collect()
+            })
+            .unwrap_or_default();
+        for old_path in &old_paths {
+            let old_touching = find_or_cache_file_changes(
+                &commit_hashes,
+                git_info,
+                Some(branch.clone()),
+                old_path,
+                disk_cache,
+            )
+            .map_err(IssueError::GitFileOpsError)?;
+            file_touching.extend(old_touching);
+        }
 
         let mut issue_commits = Vec::new();
         let mut qc_notif_found = false;
@@ -502,6 +526,92 @@ pub fn determine_relationship_from_body(
 
     // Parent not found in child's body - indicates data inconsistency
     BlockingRelationship::Unknown
+}
+
+/// A single file rename event stored in the "## File History" section of an issue body.
+///
+/// Format: `* \`old_path\` → \`new_path\` (commit: abc1234)`
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FileRenameEvent {
+    pub old_path: String,
+    pub new_path: String,
+    pub commit: String,
+}
+
+/// Parse file rename events from the "## File History" section of an issue body.
+///
+/// Each line has the form: `* \`old_path\` → \`new_path\` (commit: abc1234)`
+pub fn parse_file_history(body: &str) -> Vec<FileRenameEvent> {
+    let section_start = match body.find("## File History") {
+        Some(pos) => pos,
+        None => return vec![],
+    };
+
+    let section = &body[section_start..];
+    let section_end = section["## File History".len()..]
+        .find("\n## ")
+        .map(|pos| pos + "## File History".len())
+        .unwrap_or(section.len());
+    let section = &section[..section_end];
+
+    let mut events = Vec::new();
+    for line in section.lines() {
+        let line = line.trim();
+        if !line.starts_with("* `") {
+            continue;
+        }
+        // Line: * `old_path` → `new_path` (commit: abc1234)
+        let rest = &line[3..]; // skip "* `"
+        let old_end = match rest.find('`') {
+            Some(i) => i,
+            None => continue,
+        };
+        let old_path = rest[..old_end].to_string();
+
+        let after_old = &rest[old_end + 1..]; // after closing `
+        // find " → `"
+        let arrow = " \u{2192} `";
+        let new_start = match after_old.find(arrow) {
+            Some(i) => i + arrow.len(),
+            None => continue,
+        };
+        let after_arrow = &after_old[new_start..];
+        let new_end = match after_arrow.find('`') {
+            Some(i) => i,
+            None => continue,
+        };
+        let new_path = after_arrow[..new_end].to_string();
+
+        // find "(commit: ...)"
+        let commit_prefix = "(commit: ";
+        let commit = match after_arrow[new_end + 1..].find(commit_prefix) {
+            Some(i) => {
+                let commit_start = i + commit_prefix.len();
+                let rest = &after_arrow[new_end + 1 + commit_start..];
+                match rest.find(')') {
+                    Some(end) => rest[..end].to_string(),
+                    None => continue,
+                }
+            }
+            None => continue,
+        };
+
+        events.push(FileRenameEvent { old_path, new_path, commit });
+    }
+
+    events
+}
+
+/// Generate the markdown for a "## File History" section.
+pub fn file_history_section(events: &[FileRenameEvent]) -> String {
+    let mut section = String::from("## File History\n");
+    for event in events {
+        section.push_str(&format!(
+            "* `{}` \u{2192} `{}` (commit: {})\n",
+            event.old_path, event.new_path, event.commit
+        ));
+    }
+    section
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -596,7 +596,11 @@ pub fn parse_file_history(body: &str) -> Vec<FileRenameEvent> {
             None => continue,
         };
 
-        events.push(FileRenameEvent { old_path, new_path, commit });
+        events.push(FileRenameEvent {
+            old_path,
+            new_path,
+            commit,
+        });
     }
 
     events
@@ -1843,7 +1847,10 @@ author: test"#;
             commit: "deadbeef".to_string(),
         }];
         let section = file_history_section(&events);
-        assert_eq!(section, "## File History\n* `src/old.R` → `src/new.R` (commit: deadbeef)\n");
+        assert_eq!(
+            section,
+            "## File History\n* `src/old.R` → `src/new.R` (commit: deadbeef)\n"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,11 +55,13 @@ pub use git::{
     GitCommand, GitComment, GitCommit, GitCommitAnalysis, GitCommitAnalysisError, GitFileOps,
     GitFileOpsError, GitHelpers, GitHubApiError, GitHubReader, GitHubWriter, GitInfo, GitInfoError,
     GitProvider, GitRepository, GitRepositoryError, GitState, GitStatus, GitStatusError,
-    GitStatusOps, RepoUser, find_commits, find_or_cache_file_changes, get_git_status,
+    GitStatusOps, RepoUser, detect_renames, find_commits, find_or_cache_file_changes,
+    get_git_status, head_commit_hash,
 };
 pub use issue::{
-    BlockingQC, BlockingRelationship, CommitStatus, IssueCommit, IssueError, IssueThread,
-    determine_relationship_from_body, parse_blocking_qcs, parse_branch_from_body,
+    BlockingQC, BlockingRelationship, CommitStatus, FileRenameEvent, IssueCommit, IssueError,
+    IssueThread, determine_relationship_from_body, file_history_section, parse_blocking_qcs,
+    parse_branch_from_body, parse_file_history,
 };
 pub use qc_status::{
     BlockingQCStatus, ChecklistSummary, QCStatus, QCStatusError, analyze_issue_checklists,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,8 @@ pub use git::{
 };
 pub use issue::{
     BlockingQC, BlockingRelationship, CommitStatus, FileRenameEvent, IssueCommit, IssueError,
-    IssueThread, determine_relationship_from_body, file_history_section, parse_blocking_qcs,
-    parse_branch_from_body, parse_file_history,
+    IssueThread, determine_relationship_from_body, file_history_section, find_checklist_start,
+    parse_blocking_qcs, parse_branch_from_body, parse_file_history, splice_file_history,
 };
 pub use qc_status::{
     BlockingQCStatus, ChecklistSummary, QCStatus, QCStatusError, analyze_issue_checklists,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,9 @@ use std::path::PathBuf;
 use ghqctoolkit::AuthStore;
 use ghqctoolkit::cli::{
     FileCommitPair, FileCommitPairParser, IssueUrlArg, IssueUrlArgParser, MilestoneSelectionFilter,
-    RelevantFileArg, RelevantFileArgParser, find_issue, generate_archive_name,
-    get_milestone_issue_threads, gh_auth_login, gh_auth_logout, gh_auth_status, gh_auth_token,
-    confirm_rename_noninteractive, interactive_milestone_status, interactive_rename,
+    RelevantFileArg, RelevantFileArgParser, confirm_rename_noninteractive, find_issue,
+    generate_archive_name, get_milestone_issue_threads, gh_auth_login, gh_auth_logout,
+    gh_auth_status, gh_auth_token, interactive_milestone_status, interactive_rename,
     interactive_status, milestone_status, prompt_archive, prompt_context_files,
     prompt_milestone_record, single_issue_status,
 };
@@ -656,12 +656,16 @@ async fn main() -> Result<()> {
                             let milestone = all_milestones
                                 .iter()
                                 .find(|m| m.title == milestone_name)
-                                .ok_or_else(|| anyhow!("No milestone found with name '{milestone_name}'"))?;
+                                .ok_or_else(|| {
+                                    anyhow!("No milestone found with name '{milestone_name}'")
+                                })?;
                             let issues = git_info.get_issues(Some(milestone.number as u64)).await?;
                             let issue = issues
                                 .iter()
                                 .find(|i| PathBuf::from(&i.title) == old_file)
-                                .ok_or_else(|| anyhow!("No open issue found for file '{}'", old_file.display()))?;
+                                .ok_or_else(|| {
+                                    anyhow!("No open issue found for file '{}'", old_file.display())
+                                })?;
                             confirm_rename_noninteractive(&git_info, issue, &old_file).await?;
                             println!("✅ Issue #{} renamed.", issue.number);
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,9 @@ use ghqctoolkit::cli::{
     FileCommitPair, FileCommitPairParser, IssueUrlArg, IssueUrlArgParser, MilestoneSelectionFilter,
     RelevantFileArg, RelevantFileArgParser, find_issue, generate_archive_name,
     get_milestone_issue_threads, gh_auth_login, gh_auth_logout, gh_auth_status, gh_auth_token,
-    interactive_milestone_status, interactive_status, milestone_status, prompt_archive,
-    prompt_context_files, prompt_milestone_record, single_issue_status,
+    confirm_rename_noninteractive, interactive_milestone_status, interactive_rename,
+    interactive_status, milestone_status, prompt_archive, prompt_context_files,
+    prompt_milestone_record, single_issue_status,
 };
 use ghqctoolkit::utils::StdEnvProvider;
 use ghqctoolkit::{
@@ -265,6 +266,17 @@ enum IssueCommands {
 
         /// File path of issue to check status for (will prompt if not provided)
         #[arg(short, long)]
+        file: Option<PathBuf>,
+    },
+    /// Confirm detected file renames and update issue titles
+    Rename {
+        /// Milestone to check for renames (will prompt if not provided)
+        #[arg(short, long)]
+        milestone: Option<String>,
+
+        /// File path of the issue to rename (auto-detects the new path from git history).
+        /// Requires --milestone. Skips interactive prompts.
+        #[arg(short, long, requires = "milestone")]
         file: Option<PathBuf>,
     },
 }
@@ -634,6 +646,43 @@ async fn main() -> Result<()> {
                     println!("{}", review_url);
                     if let Some(message) = stash.message {
                         println!("{}", message);
+                    }
+                }
+                IssueCommands::Rename { milestone, file } => {
+                    match (milestone, file) {
+                        (Some(milestone_name), Some(old_file)) => {
+                            // Non-interactive: auto-detect the new path for the specified file.
+                            let all_milestones = git_info.get_milestones().await?;
+                            let milestone = all_milestones
+                                .iter()
+                                .find(|m| m.title == milestone_name)
+                                .ok_or_else(|| anyhow!("No milestone found with name '{milestone_name}'"))?;
+                            let issues = git_info.get_issues(Some(milestone.number as u64)).await?;
+                            let issue = issues
+                                .iter()
+                                .find(|i| PathBuf::from(&i.title) == old_file)
+                                .ok_or_else(|| anyhow!("No open issue found for file '{}'", old_file.display()))?;
+                            confirm_rename_noninteractive(&git_info, issue, &old_file).await?;
+                            println!("✅ Issue #{} renamed.", issue.number);
+                        }
+                        (milestone_opt, None) => {
+                            // Interactive mode: prompt for milestone (or use provided), detect, confirm each.
+                            let all_milestones = git_info.get_milestones().await?;
+                            let milestones = if let Some(name) = milestone_opt {
+                                let filtered: Vec<Milestone> = all_milestones
+                                    .into_iter()
+                                    .filter(|m| m.title == name)
+                                    .collect();
+                                if filtered.is_empty() {
+                                    bail!("No milestone found with name '{name}'");
+                                }
+                                filtered
+                            } else {
+                                all_milestones
+                            };
+                            interactive_rename(&milestones, &git_info).await?;
+                        }
+                        _ => unreachable!("clap requires = constraints prevent partial args"),
                     }
                 }
                 IssueCommands::Status { milestone, file } => {

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -1,4 +1,4 @@
-import { useQueries, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query'
 import { API_BASE } from '../config'
 
 export type RelevantFileKind = 'blocking_qc' | 'previous_qc' | 'relevant_qc' | 'file'
@@ -7,6 +7,12 @@ export interface RelevantFileInfo {
   file_name: string
   kind: RelevantFileKind
   issue_url: string | null
+}
+
+export interface FileRenameEvent {
+  old_path: string
+  new_path: string
+  commit: string
 }
 
 export interface Issue {
@@ -24,6 +30,7 @@ export interface Issue {
   branch: string | null
   checklist_name: string | null
   relevant_files: RelevantFileInfo[]
+  file_history: FileRenameEvent[]
 }
 
 export interface IssueCommit {
@@ -485,4 +492,76 @@ export function useAllMilestoneIssues(milestoneNumbers: number[], enabled = true
     issues: queries.flatMap((q) => q.data ?? []),
     isLoading: enabled && queries.some((q) => q.isPending && q.fetchStatus !== 'idle'),
   }
+}
+
+// ---------------------------------------------------------------------------
+// File rename detection and confirmation
+// ---------------------------------------------------------------------------
+
+export interface DetectedRename {
+  issue_number: number
+  old_path: string
+  new_path: string
+}
+
+export interface DetectedRenameWithMilestone extends DetectedRename {
+  milestone_number: number
+}
+
+export async function fetchMilestoneRenames(milestoneNumber: number): Promise<DetectedRename[]> {
+  const res = await fetch(`${API_BASE}/milestones/${milestoneNumber}/renames`)
+  if (!res.ok) throw new Error(`Failed to fetch renames for milestone ${milestoneNumber}: ${res.status}`)
+  return res.json()
+}
+
+export async function postRenameIssue(issueNumber: number, newPath: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/issues/${issueNumber}/rename`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ new_path: newPath }),
+  })
+  if (!res.ok) {
+    const data = await res.json().catch(() => null)
+    throw new Error(data?.error ?? `Failed to confirm rename: ${res.status}`)
+  }
+}
+
+/** Fetch detected renames for all provided milestone numbers, merged into one list.
+ *  Each entry is annotated with the milestone_number it came from. */
+export function useRenames(milestoneNumbers: number[]) {
+  const queries = useQueries({
+    queries: milestoneNumbers.map((n) => ({
+      queryKey: ['milestones', n, 'renames'],
+      queryFn: () => fetchMilestoneRenames(n),
+      // Refresh on window focus so renames are detected promptly after a git operation.
+      staleTime: 30 * 1000,
+    })),
+  })
+  return {
+    renames: queries.flatMap((q, i) =>
+      (q.data ?? []).map((r): DetectedRenameWithMilestone => ({
+        ...r,
+        milestone_number: milestoneNumbers[i],
+      })),
+    ),
+    isLoading: queries.some((q) => q.isPending && q.fetchStatus !== 'idle'),
+  }
+}
+
+/** Mutation that confirms a rename and invalidates the affected milestone queries. */
+export function useConfirmRename(milestoneNumbers: number[]) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ issueNumber, newPath }: { issueNumber: number; newPath: string }) =>
+      postRenameIssue(issueNumber, newPath),
+    onSuccess: (_, { issueNumber }) => {
+      // Invalidate the issue's own status cache so its card title refreshes immediately.
+      void queryClient.invalidateQueries({ queryKey: ['issue', 'status', issueNumber] })
+      // Invalidate milestone issues and renames so the banner clears and issue list updates.
+      for (const n of milestoneNumbers) {
+        void queryClient.invalidateQueries({ queryKey: ['milestones', n, 'issues'] })
+        void queryClient.invalidateQueries({ queryKey: ['milestones', n, 'renames'] })
+      }
+    },
+  })
 }

--- a/ui/src/components/CreateIssueModal.tsx
+++ b/ui/src/components/CreateIssueModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Button, Group, Modal, ScrollArea, Tabs, Text } from '@mantine/core'
+import { Alert, Button, Group, Modal, ScrollArea, Tabs, Text } from '@mantine/core'
+import { IconInfoCircle } from '@tabler/icons-react'
 import { FileTreeBrowser } from './FileTreeBrowser'
 import { IssuePreviewCard } from './IssuePreviewCard'
 import { ChecklistTab } from './ChecklistTab'
@@ -8,7 +9,7 @@ import { ReviewersTab } from './ReviewersTab'
 import { CollaboratorsTab } from './CollaboratorsTab'
 import type { ChecklistDraft } from './ChecklistTab'
 import { useRepoInfo } from '~/api/repo'
-import { useIssuesForMilestone } from '~/api/issues'
+import { useIssuesForMilestone, useRenames } from '~/api/issues'
 import { useChecklistDisplayName, useConfigurationStatus } from '~/api/configuration'
 import { capitalize } from '~/utils/displayName'
 import type { RelevantFileKind } from '~/api/issues'
@@ -145,7 +146,7 @@ export function CreateIssueModal({ opened, onClose, milestoneNumber, milestoneTi
           filePreviewMode: isMissing ? 'missing' : 'unsupported',
           filePreviewContent: isMissing
             ? `Error: ${message}`
-            : `Preview is not available for ${getFileExtensionLabel(modal.selectedFile)} files.`,
+            : `Preview is not available for ${getFileExtensionLabel(modal.selectedFile ?? '')} files.`,
           filePreviewOpen: true,
         },
       }))
@@ -194,6 +195,13 @@ export function CreateIssueModal({ opened, onClose, milestoneNumber, milestoneTi
     modal.checklistSelected ||
     (modal.checklistDraft.name.trim().length > 0 && modal.checklistDraft.content.trim().length > 0)
   )
+
+  // Warn if the selected file matches the new_path of a detected rename —
+  // the user may want to confirm the rename instead of creating a duplicate issue.
+  const { renames } = useRenames(milestoneNumber !== null ? [milestoneNumber] : [])
+  const renameWarning = modal.selectedFile
+    ? renames.find((r) => r.new_path === modal.selectedFile)
+    : null
 
   // Issue titles ARE the file path (e.g. "scripts/file_b.R"); build a set for O(1) lookup
   const claimedFiles = useMemo<Set<string>>(
@@ -394,6 +402,16 @@ export function CreateIssueModal({ opened, onClose, milestoneNumber, milestoneTi
             />
           </div>
         </Group>
+
+        {renameWarning && (
+          <Alert icon={<IconInfoCircle size={16} />} color="yellow" variant="light" mt="sm">
+            <Text size="sm">
+              <Text span ff="monospace" fw={600}>{renameWarning.new_path}</Text> may have been renamed from{' '}
+              <Text span ff="monospace" fw={600}>{renameWarning.old_path}</Text>, which already has QC issue #{renameWarning.issue_number}.
+              Consider confirming the rename in the Status tab instead of creating a new issue.
+            </Text>
+          </Alert>
+        )}
 
         <Group justify="flex-end" pt="sm">
           <Button

--- a/ui/src/components/FileResolveModal.tsx
+++ b/ui/src/components/FileResolveModal.tsx
@@ -265,7 +265,14 @@ function CommitIssueStep({
   )
 
   const matchingIssueNumbers = useMemo(
-    () => allIssues.filter(i => i.title === fileName).map(i => i.number),
+    () =>
+      allIssues
+        .filter(
+          (i) =>
+            i.title === fileName ||
+            i.file_history.some((e) => e.old_path === fileName || e.new_path === fileName),
+        )
+        .map((i) => i.number),
     [allIssues, fileName],
   )
 

--- a/ui/src/components/RenamePromptBanner.tsx
+++ b/ui/src/components/RenamePromptBanner.tsx
@@ -1,0 +1,61 @@
+import { Alert, Button, Divider, Group, Stack, Text } from '@mantine/core'
+import { IconArrowRight, IconAlertCircle } from '@tabler/icons-react'
+import type { DetectedRenameWithMilestone } from '~/api/issues'
+
+interface Props {
+  renames: DetectedRenameWithMilestone[]
+  onConfirm: (issueNumber: number, newPath: string) => void
+  onDismiss: (issueNumber: number) => void
+  confirming: Set<number>
+  getMilestoneName: (milestoneNumber: number) => string
+}
+
+export function RenamePromptBanner({ renames, onConfirm, onDismiss, confirming, getMilestoneName }: Props) {
+  if (renames.length === 0) return null
+
+  const title = renames.length === 1 ? 'File rename detected' : `${renames.length} file renames detected`
+
+  return (
+    <Alert icon={<IconAlertCircle size={16} />} color="yellow" variant="light" title={title} mb="sm">
+      <Stack gap={6}>
+        {renames.map((r, i) => (
+          <div key={r.issue_number}>
+            {i > 0 && <Divider color="yellow.3" mb={6} />}
+            <Group justify="space-between" align="center" wrap="nowrap">
+              <Stack gap={2}>
+                <Group gap={4} align="center" wrap="nowrap">
+                  <Text span fw={600} ff="monospace" size="sm">{r.old_path}</Text>
+                  <IconArrowRight size={12} />
+                  <Text span fw={600} ff="monospace" size="sm">{r.new_path}</Text>
+                </Group>
+                <Text size="xs" c="dimmed">
+                  Issue #{r.issue_number} · {getMilestoneName(r.milestone_number)}
+                </Text>
+              </Stack>
+              <Group gap="xs" wrap="nowrap" style={{ flexShrink: 0 }}>
+                <Button
+                  size="xs"
+                  variant="filled"
+                  color="yellow"
+                  loading={confirming.has(r.issue_number)}
+                  onClick={() => onConfirm(r.issue_number, r.new_path)}
+                >
+                  Confirm
+                </Button>
+                <Button
+                  size="xs"
+                  variant="subtle"
+                  color="gray"
+                  disabled={confirming.has(r.issue_number)}
+                  onClick={() => onDismiss(r.issue_number)}
+                >
+                  Dismiss
+                </Button>
+              </Group>
+            </Group>
+          </div>
+        ))}
+      </Stack>
+    </Alert>
+  )
+}

--- a/ui/src/components/StatusTab.tsx
+++ b/ui/src/components/StatusTab.tsx
@@ -1,6 +1,10 @@
+import { useState } from 'react'
+import { Alert } from '@mantine/core'
 import { useRepoInfo } from '~/api/repo'
-import { useMilestoneIssues } from '~/api/issues'
+import { useConfirmRename, useMilestoneIssues, useRenames } from '~/api/issues'
+import { useMilestones } from '~/api/milestones'
 import { SwimLanes } from './SwimLanes'
+import { RenamePromptBanner } from './RenamePromptBanner'
 import { useUiSession } from '~/state/uiSession'
 
 export function StatusTab() {
@@ -16,13 +20,62 @@ export function StatusTab() {
     !entry.dirty && dirtyFiles.has(entry.issue.title) ? { ...entry, dirty: true } : entry,
   )
 
+  // Rename detection — runs in the background; empty while milestones are loading.
+  const { data: milestones = [] } = useMilestones()
+  const getMilestoneName = (n: number) => milestones.find((m) => m.number === n)?.title ?? `#${n}`
+  const { renames } = useRenames(status.selectedMilestones)
+  const confirmRename = useConfirmRename(status.selectedMilestones)
+  const [dismissed, setDismissed] = useState<Set<number>>(new Set())
+  const [confirming, setConfirming] = useState<Set<number>>(new Set())
+  const [renameError, setRenameError] = useState<string | null>(null)
+
+  const visibleRenames = renames.filter((r) => !dismissed.has(r.issue_number))
+
+  function handleConfirm(issueNumber: number, newPath: string) {
+    setConfirming((prev) => new Set(prev).add(issueNumber))
+    setRenameError(null)
+    confirmRename.mutate(
+      { issueNumber, newPath },
+      {
+        onSettled: () => {
+          setConfirming((prev) => {
+            const next = new Set(prev)
+            next.delete(issueNumber)
+            return next
+          })
+        },
+        onError: (error) => {
+          setRenameError(error instanceof Error ? error.message : 'Failed to confirm rename')
+        },
+      },
+    )
+  }
+
+  function handleDismiss(issueNumber: number) {
+    setDismissed((prev) => new Set(prev).add(issueNumber))
+  }
+
   return (
-    <div style={{ height: '100%', minHeight: 0 }}>
-      <SwimLanes
-        statuses={statuses}
-        currentBranch={repoData?.branch ?? ''}
-        remoteCommit={repoData?.remote_commit ?? ''}
+    <div style={{ height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+      <RenamePromptBanner
+        renames={visibleRenames}
+        onConfirm={handleConfirm}
+        onDismiss={handleDismiss}
+        confirming={confirming}
+        getMilestoneName={getMilestoneName}
       />
+      {renameError && (
+        <Alert color="red" mb="xs" title="Rename failed" withCloseButton onClose={() => setRenameError(null)}>
+          {renameError}
+        </Alert>
+      )}
+      <div style={{ flex: 1, minHeight: 0 }}>
+        <SwimLanes
+          statuses={statuses}
+          currentBranch={repoData?.branch ?? ''}
+          remoteCommit={repoData?.remote_commit ?? ''}
+        />
+      </div>
     </div>
   )
 }

--- a/ui/src/components/SwimLanes.tsx
+++ b/ui/src/components/SwimLanes.tsx
@@ -73,7 +73,7 @@ export function SwimLanes({ statuses, currentBranch, remoteCommit }: Props) {
                       <div
                         ref={provided.innerRef}
                         {...provided.droppableProps}
-                        style={{ minHeight: 120, flex: 1, minHeight: 0, overflowY: 'auto', paddingRight: 4 }}
+                        style={{ flex: 1, minHeight: 0, overflowY: 'auto', paddingRight: 4 }}
                       >
                         {cards.map((s, index) => (
                           <Draggable

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -5,7 +5,6 @@
     "module": "ESNext",
     "target": "ES2022",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "baseUrl": ".",
     "paths": {
       "~/*": ["./src/*"]
     },


### PR DESCRIPTION
Based on feedback, it is not uncommon for a file to be renamed mid-QC due to necessary creation of similar files (i.e. VPC.qmd -> VPC_001.qmd to make room for VPC_002.qmd and VPC_003.qmd).

GHQC previously did not handle this scenario well. File history is traced through the issue name and re-naming a file would make it lose consistency with the current issue. It was also found user would _try_ to implement such a change by hand, but would typically cause downstream issues.

Because of this, this PR introduces a new feature to help with the rename of files. It tracks the git history of the files selected in a milestone and sees if they have been renamed. If they have, a suggestion is prompted to the user to rename the issue in the ui and the interactive terminal. 