### PR TITLE
Notify Commit Scrollbar

### DIFF
--- a/ui/src/components/IssueDetailModal.tsx
+++ b/ui/src/components/IssueDetailModal.tsx
@@ -389,7 +389,6 @@ function NotifyTab({ status, onStatusUpdate }: { status: IssueStatusResponse; on
       title="Comment Preview"
       size={800}
       centered
-      withinPortal={false}
       styles={{ header: { paddingTop: 12, paddingBottom: 12 }, body: { paddingBottom: 20 } }}
     >
       <iframe
@@ -406,7 +405,6 @@ function NotifyTab({ status, onStatusUpdate }: { status: IssueStatusResponse; on
       title={postError ? 'Post Failed' : 'Comment Posted'}
       size="sm"
       centered
-      withinPortal={false}
     >
       {postError ? (
         <Text c="red" size="sm">{postError}</Text>
@@ -741,7 +739,6 @@ function ReviewTab({ status, onStatusUpdate }: { status: IssueStatusResponse; on
       title="Comment Preview"
       size={800}
       centered
-      withinPortal={false}
       styles={{ header: { paddingTop: 12, paddingBottom: 12 }, body: { paddingBottom: 20 } }}
     >
       <iframe
@@ -757,7 +754,6 @@ function ReviewTab({ status, onStatusUpdate }: { status: IssueStatusResponse; on
       title={postError ? 'Post Failed' : 'Comment Posted'}
       size="sm"
       centered
-      withinPortal={false}
     >
       {postError ? (
         <Text c="red" size="sm">{postError}</Text>
@@ -1023,7 +1019,6 @@ function ApproveTab({ status, onStatusUpdate }: { status: IssueStatusResponse; o
       title="Comment Preview"
       size={800}
       centered
-      withinPortal={false}
       styles={{ header: { paddingTop: 12, paddingBottom: 12 }, body: { paddingBottom: 20 } }}
     >
       <iframe
@@ -1039,7 +1034,6 @@ function ApproveTab({ status, onStatusUpdate }: { status: IssueStatusResponse; o
       title={postError ? 'Approve Failed' : 'Approved'}
       size="sm"
       centered
-      withinPortal={false}
     >
       {postError ? (
         <Text c="red" size="sm">{postError}</Text>


### PR DESCRIPTION
It was reported a "gray horizontal bar covered the exit button when trying to exit the success modal" from the notification modal. 

It was found to be the commit scrollbar not staying on its proper layer and highlighting when hovered over