### PR TITLE
"Ready for Review" default modal tab

### DIFF
--- a/ui/src/components/IssueDetailModal.tsx
+++ b/ui/src/components/IssueDetailModal.tsx
@@ -63,8 +63,13 @@ export function IssueDetailModal({ status, onClose, onStatusUpdate }: Props) {
 function defaultTab(status: IssueStatusResponse): string {
   switch (status.qc_status.status) {
     case 'awaiting_review':
-    case 'approval_required':
-      return status.dirty ? 'review' : 'approve'
+    case 'approval_required': {
+      const checklist = status.checklist_summary
+      const checklistComplete = checklist.total === 0 || checklist.completed === checklist.total
+      const blocking = status.blocking_qc_status
+      const blockingComplete = !blocking || blocking.total === 0 || blocking.approved_count === blocking.total
+      return checklistComplete && blockingComplete ? 'approve' : 'review'
+    }
     case 'change_requested':
     case 'in_progress':
     case 'changes_to_comment':


### PR DESCRIPTION
Before, the default tab that would open in the modal pop-up for issues with status "Ready for Review" was *Approve*. The tab would only default to *Review* if the file was dirty.

Based on feedback, it makes more sense to have the default be *Review* and only default to *Approve* if all checklist items and all gating/relevant QCs have been approved. This is to prevent a user accidentally approving an issue that review is still needed on and is more intuitive.