### PR TITLE
status color tooltip + approve comment lock

### DIFF
--- a/ui/src/components/IssueDetailModal.tsx
+++ b/ui/src/components/IssueDetailModal.tsx
@@ -102,10 +102,10 @@ function ModalContent({ status, onClose, onStatusUpdate }: { status: IssueStatus
       </Group>
 
       <Tabs.Panel value="notify" pt="md" px="md" pb="md" style={{ flex: 1, overflowY: 'auto' }}>
-        <NotifyTab status={status} onStatusUpdate={onStatusUpdate} />
+        <NotifyTab status={status} onStatusUpdate={onStatusUpdate} isApproved={isApproved} />
       </Tabs.Panel>
       <Tabs.Panel value="review" pt="md" px="md" pb="md" style={{ flex: 1, overflowY: 'auto' }}>
-        <ReviewTab status={status} onStatusUpdate={onStatusUpdate} />
+        <ReviewTab status={status} onStatusUpdate={onStatusUpdate} isApproved={isApproved} />
       </Tabs.Panel>
       <Tabs.Panel value="approve" pt="md" px="md" pb="md" style={{ flex: 1, overflowY: 'auto' }}>
         <ApproveTab status={status} onStatusUpdate={onStatusUpdate} />
@@ -117,7 +117,7 @@ function ModalContent({ status, onClose, onStatusUpdate }: { status: IssueStatus
   )
 }
 
-function NotifyTab({ status, onStatusUpdate }: { status: IssueStatusResponse; onStatusUpdate: (status: IssueStatusResponse) => void }) {
+function NotifyTab({ status, onStatusUpdate, isApproved }: { status: IssueStatusResponse; onStatusUpdate: (status: IssueStatusResponse) => void; isApproved: boolean }) {
   const { issue } = status
 
   // Build oldest-first commit list
@@ -163,6 +163,7 @@ function NotifyTab({ status, onStatusUpdate }: { status: IssueStatusResponse; on
   const [postResultOpen, setPostResultOpen] = useState(false)
   const [postResultUrl, setPostResultUrl] = useState<string | null>(null)
   const [postError, setPostError] = useState<string | null>(null)
+  const [ackApproved, setAckApproved] = useState(false)
   const queryClient = useQueryClient()
 
   // Reset when the status prop changes (different issue opened)
@@ -176,6 +177,7 @@ function NotifyTab({ status, onStatusUpdate }: { status: IssueStatusResponse; on
     setPostResultOpen(false)
     setPostResultUrl(null)
     setPostError(null)
+    setAckApproved(false)
   }, [status.issue.number]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const visibleCommits = orderedCommits
@@ -262,6 +264,19 @@ function NotifyTab({ status, onStatusUpdate }: { status: IssueStatusResponse; on
     <>
     <Stack gap="md">
       <StatusCard status={status} />
+
+      {isApproved && (
+        <Alert color="orange">
+          <Text size="sm" fw={600}>This issue is already approved</Text>
+          <Text size="xs" mt={4}>Consider unapproving first before posting a notification comment.</Text>
+          <Checkbox
+            mt="xs"
+            label="Notify anyway"
+            checked={ackApproved}
+            onChange={(e) => setAckApproved(e.currentTarget.checked)}
+          />
+        </Alert>
+      )}
 
       {/* Commit range slider */}
       {visibleCommits.length > 0 && (
@@ -377,7 +392,7 @@ function NotifyTab({ status, onStatusUpdate }: { status: IssueStatusResponse; on
             </Button>
             <Button
               loading={postLoading}
-              disabled={!toCommit}
+              disabled={!toCommit || (isApproved && !ackApproved)}
               onClick={handlePost}
             >
               Post
@@ -510,7 +525,7 @@ function StatusCard({ status }: { status: IssueStatusResponse }) {
 // ---------------------------------------------------------------------------
 // Review tab — single commit selector, diff against working directory
 // ---------------------------------------------------------------------------
-function ReviewTab({ status, onStatusUpdate }: { status: IssueStatusResponse; onStatusUpdate: (status: IssueStatusResponse) => void }) {
+function ReviewTab({ status, onStatusUpdate, isApproved }: { status: IssueStatusResponse; onStatusUpdate: (status: IssueStatusResponse) => void; isApproved: boolean }) {
   const { issue } = status
 
   const orderedCommits = [...status.commits].reverse()
@@ -539,6 +554,7 @@ function ReviewTab({ status, onStatusUpdate }: { status: IssueStatusResponse; on
   const [postResultUrl, setPostResultUrl] = useState<string | null>(null)
   const [postStashResult, setPostStashResult] = useState<ReviewStashResult | null>(null)
   const [postError, setPostError] = useState<string | null>(null)
+  const [ackApproved, setAckApproved] = useState(false)
   const queryClient = useQueryClient()
 
   useEffect(() => {
@@ -552,6 +568,7 @@ function ReviewTab({ status, onStatusUpdate }: { status: IssueStatusResponse; on
     setPostResultUrl(null)
     setPostStashResult(null)
     setPostError(null)
+    setAckApproved(false)
   }, [status.issue.number]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const visibleCommits = orderedCommits
@@ -628,6 +645,19 @@ function ReviewTab({ status, onStatusUpdate }: { status: IssueStatusResponse; on
     <>
     <Stack gap="md">
       <StatusCard status={status} />
+
+      {isApproved && (
+        <Alert color="orange">
+          <Text size="sm" fw={600}>This issue is already approved</Text>
+          <Text size="xs" mt={4}>Consider unapproving first before posting a review comment.</Text>
+          <Checkbox
+            mt="xs"
+            label="Review anyway"
+            checked={ackApproved}
+            onChange={(e) => setAckApproved(e.currentTarget.checked)}
+          />
+        </Alert>
+      )}
 
       {visibleCommits.length > 0 && (
         <Stack gap="xs">
@@ -728,7 +758,7 @@ function ReviewTab({ status, onStatusUpdate }: { status: IssueStatusResponse; on
             </Button>
             <Button
               loading={postLoading}
-              disabled={!selectedCommit}
+              disabled={!selectedCommit || (isApproved && !ackApproved)}
               onClick={handlePost}
             >
               Post

--- a/ui/src/components/SwimLanes.tsx
+++ b/ui/src/components/SwimLanes.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Card, Stack, Text, Title } from '@mantine/core'
+import { Card, Stack, Text, Title, Tooltip } from '@mantine/core'
 import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd'
 import type { IssueStatusResponse, QCStatus } from '~/api/issues'
 import { IssueCard } from './IssueCard'
@@ -75,37 +75,53 @@ export function SwimLanes({ statuses, currentBranch, remoteCommit }: Props) {
                         {...provided.droppableProps}
                         style={{ flex: 1, minHeight: 0, overflowY: 'auto', paddingRight: 4 }}
                       >
-                        {cards.map((s, index) => (
+                        {cards.map((s, index) => {
+                          const postApprovalCommit = postApprovalFileCommit(s)
+                          const colorTooltip =
+                            s.qc_status.status === 'approval_required'
+                              ? 'Issue was closed without approval'
+                              : postApprovalCommit
+                              ? 'File has changed since approval'
+                              : null
+                          return (
                           <Draggable
                             key={s.issue.number}
                             draggableId={String(s.issue.number)}
                             index={index}
                             isDragDisabled
                           >
-                            {(p) => (
-                              <Card
-                                ref={p.innerRef}
-                                {...p.draggableProps}
-                                {...p.dragHandleProps}
-                                withBorder
-                                mb={8}
-                                p={10}
-                                onClick={() => setSelected(s)}
-                                data-testid={`issue-card-${s.issue.number}`}
-                                style={{
-                                  cursor: 'pointer',
-                                  ...(s.qc_status.status === 'approval_required'
-                                    ? { backgroundColor: '#fee2e2' }
-                                    : postApprovalFileCommit(s)
-                                    ? { backgroundColor: '#ffedd5' }
-                                    : undefined),
-                                }}
-                              >
-                                <IssueCard status={s} currentBranch={currentBranch} remoteCommit={remoteCommit} postApprovalCommit={postApprovalFileCommit(s)} />
-                              </Card>
-                            )}
+                            {(p) => {
+                              const card = (
+                                <Card
+                                  ref={p.innerRef}
+                                  {...p.draggableProps}
+                                  {...p.dragHandleProps}
+                                  withBorder
+                                  mb={8}
+                                  p={10}
+                                  onClick={() => setSelected(s)}
+                                  data-testid={`issue-card-${s.issue.number}`}
+                                  style={{
+                                    cursor: 'pointer',
+                                    ...(s.qc_status.status === 'approval_required'
+                                      ? { backgroundColor: '#fee2e2' }
+                                      : postApprovalCommit
+                                      ? { backgroundColor: '#ffedd5' }
+                                      : undefined),
+                                  }}
+                                >
+                                  <IssueCard status={s} currentBranch={currentBranch} remoteCommit={remoteCommit} postApprovalCommit={postApprovalCommit} />
+                                </Card>
+                              )
+                              return colorTooltip ? (
+                                <Tooltip label={colorTooltip} withArrow position="top" openDelay={300}>
+                                  {card}
+                                </Tooltip>
+                              ) : card
+                            }}
                           </Draggable>
-                        ))}
+                          )
+                        })}
                         {cards.length === 0 && (
                           <Text c="dimmed" size="sm" style={{ textAlign: 'center', paddingTop: 8 }}>
                             Empty


### PR DESCRIPTION
Based on feedback, users were commenting on approved issues and not unapproving first. This PR addresses this in two ways:

* Tooltip - The status tab uses colors to indicate more emergent states (unapproved closed issues, changes after approval, etc.). While opening the issue card will explain this more, it is not clear in the status frame. To make these statuses clearer (particularly changes after approval), a tooltip is added to indicate what's happening.
* Warning Checkboxes - For approved issues, the notify and review tabs get a warning note indicating that its recommended to unapprove the issue before posting a comment. A checkbox must be checked in order to post in this situation in the cases where a notification/review on an approve issue actually is desired