### PR TITLE
Status tooltips

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1140,15 +1140,34 @@ components:
 
     BlockingQCError:
       type: object
+      required: [issue_number, error, kind]
       properties:
         issue_number:
           type: integer
         error:
           type: string
+        kind:
+          $ref: '#/components/schemas/IssueStatusErrorKind'
+        file_name:
+          type: string
+          description: >-
+            Title of the QC'd file. Present for processing failures (incl.
+            `branch_not_local`) since the issue was fetched; absent for
+            `fetch_failed` errors where the issue body was never retrieved.
+        branch:
+          type: string
+          description: >-
+            The branch ref the user needs to fetch / track locally. Set when
+            `kind == branch_not_local`; absent otherwise.
 
     IssueStatusErrorKind:
       type: string
-      enum: [fetch_failed, processing_failed]
+      description: >-
+        - `fetch_failed`: the issue itself could not be fetched from GitHub.
+        - `processing_failed`: the issue was fetched but its thread/cache could not be built.
+        - `branch_not_local`: the issue's branch ref isn't checked out locally; the response
+          includes a `branch` field naming it.
+      enum: [fetch_failed, processing_failed, branch_not_local]
 
     IssueStatusError:
       type: object
@@ -1160,6 +1179,11 @@ components:
           $ref: '#/components/schemas/IssueStatusErrorKind'
         error:
           type: string
+        branch:
+          type: string
+          description: >-
+            The branch ref the user needs to fetch / track locally. Set when
+            `kind == branch_not_local`; absent otherwise.
 
     BatchIssueStatusResponse:
       type: object
@@ -1443,6 +1467,7 @@ components:
       required:
         - owner
         - repo
+        - remote
         - branch
         - local_commit
         - remote_commit
@@ -1456,6 +1481,12 @@ components:
         repo:
           type: string
           description: Repository name
+        remote:
+          type: string
+          description: >-
+            Name of the user's default remote (typically "origin", but
+            configurable via `git clone --origin <name>` or rename).
+          example: origin
         branch:
           type: string
           description: Current branch name

--- a/src/api/fetch_helpers.rs
+++ b/src/api/fetch_helpers.rs
@@ -8,10 +8,10 @@ use crate::{
     get_issue_comments, parse_blocking_qcs,
 };
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub(crate) struct FetchedIssues {
     pub(crate) issues: Vec<Issue>,
-    pub(crate) errors: HashMap<u64, String>,
+    pub(crate) errors: HashMap<u64, IssueError>,
 }
 
 impl FetchedIssues {
@@ -27,7 +27,9 @@ impl FetchedIssues {
             match result {
                 Ok(issue) => fetched.issues.push(issue),
                 Err(e) => {
-                    fetched.errors.insert(*issue_number, e.to_string());
+                    fetched
+                        .errors
+                        .insert(*issue_number, IssueError::GitHubApiError(e));
                 }
             }
         }

--- a/src/api/routes/comments.rs
+++ b/src/api/routes/comments.rs
@@ -201,9 +201,7 @@ pub(crate) async fn get_blocking_qc_status<G: GitProvider>(
     let mut fetched_issues = FetchedIssues::fetch_issues(blocking_qcs, git_info).await;
 
     let created_threads = CreatedThreads::create_threads(&fetched_issues.issues, state).await;
-    fetched_issues
-        .errors
-        .extend(created_threads.thread_errors);
+    fetched_issues.errors.extend(created_threads.thread_errors);
 
     let titles: std::collections::HashMap<u64, String> = fetched_issues
         .issues

--- a/src/api/routes/comments.rs
+++ b/src/api/routes/comments.rs
@@ -201,28 +201,22 @@ pub(crate) async fn get_blocking_qc_status<G: GitProvider>(
     let mut fetched_issues = FetchedIssues::fetch_issues(blocking_qcs, git_info).await;
 
     let created_threads = CreatedThreads::create_threads(&fetched_issues.issues, state).await;
-    fetched_issues.errors.extend(
-        created_threads
-            .thread_errors
-            .into_iter()
-            .map(|(n, e)| (n, e.to_string())),
-    );
+    fetched_issues
+        .errors
+        .extend(created_threads.thread_errors);
 
-    status.errors.extend(
-        fetched_issues
-            .errors
-            .iter()
-            .map(|(num, err)| BlockingQCError {
-                issue_number: *num,
-                error: err.clone(),
-            }),
-    );
+    let titles: std::collections::HashMap<u64, String> = fetched_issues
+        .issues
+        .iter()
+        .map(|i| (i.number, i.title.clone()))
+        .collect();
 
     determine_blocking_qc_status(
         &mut status,
         blocking_qcs,
         &created_threads.responses,
         &fetched_issues.errors,
+        &titles,
     );
 
     status

--- a/src/api/routes/issues.rs
+++ b/src/api/routes/issues.rs
@@ -209,9 +209,7 @@ pub async fn batch_get_issue_status<G: GitProvider + 'static>(
 
     // Only create threads for successfully fetched issues.
     let created_threads = CreatedThreads::create_threads(&fetched_issues.issues, &state).await;
-    fetched_issues
-        .errors
-        .extend(created_threads.thread_errors);
+    fetched_issues.errors.extend(created_threads.thread_errors);
 
     let mut errors: Vec<IssueStatusError> = Vec::new();
     let mut responses: Vec<IssueStatusResponse> = Vec::new();

--- a/src/api/routes/issues.rs
+++ b/src/api/routes/issues.rs
@@ -209,15 +209,21 @@ pub async fn batch_get_issue_status<G: GitProvider + 'static>(
 
     // Only create threads for successfully fetched issues.
     let created_threads = CreatedThreads::create_threads(&fetched_issues.issues, &state).await;
-    fetched_issues.errors.extend(
-        created_threads
-            .thread_errors
-            .into_iter()
-            .map(|(n, e)| (n, e.to_string())),
-    );
+    fetched_issues
+        .errors
+        .extend(created_threads.thread_errors);
 
     let mut errors: Vec<IssueStatusError> = Vec::new();
     let mut responses: Vec<IssueStatusResponse> = Vec::new();
+
+    // Lookup of issue number → file title for fetched-but-failed issues, so
+    // BlockingQCError entries can name the file even when the thread couldn't
+    // be built.
+    let titles: std::collections::HashMap<u64, String> = fetched_issues
+        .issues
+        .iter()
+        .map(|i| (i.number, i.title.clone()))
+        .collect();
 
     // Preserve request ordering.
     for issue_number in &issue_numbers {
@@ -232,35 +238,33 @@ pub async fn batch_get_issue_status<G: GitProvider + 'static>(
                     .unwrap_or(&[]),
                 &created_threads.responses,
                 &fetched_issues.errors,
+                &titles,
             );
             responses.push(response);
         } else {
-            // Distinguish between fetch failures and processing failures.
-            let (kind, error) = if fetched_issues
+            let was_fetched = fetched_issues
                 .issues
                 .iter()
-                .any(|i| i.number == *issue_number)
-            {
-                // Issue was fetched but thread/cache creation failed → processing error.
-                let msg = fetched_issues
-                    .errors
-                    .get(issue_number)
-                    .cloned()
-                    .unwrap_or_else(|| "Failed to determine issue status".to_string());
-                (IssueStatusErrorKind::ProcessingFailed, msg)
+                .any(|i| i.number == *issue_number);
+            let default_kind = if was_fetched {
+                IssueStatusErrorKind::ProcessingFailed
             } else {
-                // Issue was never fetched successfully → fetch error.
-                let msg = fetched_issues
-                    .errors
-                    .get(issue_number)
-                    .cloned()
-                    .unwrap_or_else(|| "Failed to fetch issue".to_string());
-                (IssueStatusErrorKind::FetchFailed, msg)
+                IssueStatusErrorKind::FetchFailed
+            };
+            let default_msg = if was_fetched {
+                "Failed to determine issue status"
+            } else {
+                "Failed to fetch issue"
+            };
+            let (kind, error, branch) = match fetched_issues.errors.get(issue_number) {
+                Some(e) => classify_issue_error(e, default_kind),
+                None => (default_kind, default_msg.to_string(), None),
             };
             errors.push(IssueStatusError {
                 issue_number: *issue_number,
                 kind,
                 error,
+                branch,
             });
         }
     }
@@ -280,11 +284,28 @@ pub async fn batch_get_issue_status<G: GitProvider + 'static>(
     ))
 }
 
+/// Classify an `IssueError` into the API-facing `(kind, message, branch)` tuple.
+/// `default_kind` is used when the error doesn't match a more specific case.
+pub(crate) fn classify_issue_error(
+    e: &crate::IssueError,
+    default_kind: IssueStatusErrorKind,
+) -> (IssueStatusErrorKind, String, Option<String>) {
+    match e {
+        crate::IssueError::LocalBranchNotFound(name) => (
+            IssueStatusErrorKind::BranchNotLocal,
+            e.to_string(),
+            Some(name.clone()),
+        ),
+        _ => (default_kind, e.to_string(), None),
+    }
+}
+
 pub(crate) fn determine_blocking_qc_status(
     blocking_status: &mut BlockingQCStatus,
     blocking_numbers: &[u64],
     responses: &std::collections::HashMap<u64, IssueStatusResponse>,
-    errors: &std::collections::HashMap<u64, String>,
+    errors: &std::collections::HashMap<u64, crate::IssueError>,
+    titles: &std::collections::HashMap<u64, String>,
 ) {
     blocking_status.total = blocking_numbers.len() as u32;
     for number in blocking_numbers {
@@ -306,14 +327,22 @@ pub(crate) fn determine_blocking_qc_status(
                 }
             }
         } else if let Some(error) = errors.get(number) {
+            let (kind, msg, branch) =
+                classify_issue_error(error, IssueStatusErrorKind::FetchFailed);
             blocking_status.errors.push(BlockingQCError {
                 issue_number: *number,
-                error: error.to_string(),
+                error: msg,
+                kind,
+                file_name: titles.get(number).cloned(),
+                branch,
             });
         } else {
             blocking_status.errors.push(BlockingQCError {
                 issue_number: *number,
                 error: "Failed to determine status".to_string(),
+                kind: IssueStatusErrorKind::FetchFailed,
+                file_name: titles.get(number).cloned(),
+                branch: None,
             });
         }
     }

--- a/src/api/tests/cases/status/get_repo_info_ahead.yaml
+++ b/src/api/tests/cases/status/get_repo_info_ahead.yaml
@@ -22,6 +22,7 @@ response:
     value:
       owner: "test-owner"
       repo: "test-repo"
+      remote: "origin"
       branch: "main"
       local_commit: "abc1234567890abcdef1234567890abcdef12340"
       remote_commit: "9012345678901234567890abcdef1234567890ab"

--- a/src/api/tests/cases/status/get_repo_info_behind.yaml
+++ b/src/api/tests/cases/status/get_repo_info_behind.yaml
@@ -22,6 +22,7 @@ response:
     value:
       owner: "test-owner"
       repo: "test-repo"
+      remote: "origin"
       branch: "main"
       local_commit: "abc1234567890abcdef1234567890abcdef12340"
       remote_commit: "3456789012345678901234567890abcdef123456"

--- a/src/api/tests/cases/status/get_repo_info_clean.yaml
+++ b/src/api/tests/cases/status/get_repo_info_clean.yaml
@@ -19,6 +19,7 @@ response:
     value:
       owner: "test-owner"
       repo: "test-repo"
+      remote: "origin"
       branch: "main"
       local_commit: "abc1234567890abcdef1234567890abcdef12340"
       remote_commit: "abc1234567890abcdef1234567890abcdef12340"

--- a/src/api/tests/cases/status/get_repo_info_diverged.yaml
+++ b/src/api/tests/cases/status/get_repo_info_diverged.yaml
@@ -25,6 +25,7 @@ response:
     value:
       owner: "test-owner"
       repo: "test-repo"
+      remote: "origin"
       branch: "main"
       local_commit: "abc1234567890abcdef1234567890abcdef12340"
       remote_commit: "4567890123456789012345678901234567890abc"

--- a/src/api/tests/cases/status/get_repo_info_unauthenticated.yaml
+++ b/src/api/tests/cases/status/get_repo_info_unauthenticated.yaml
@@ -20,6 +20,7 @@ response:
     value:
       owner: "test-owner"
       repo: "test-repo"
+      remote: "origin"
       branch: "main"
       local_commit: "abc1234567890abcdef1234567890abcdef12340"
       remote_commit: "abc1234567890abcdef1234567890abcdef12340"

--- a/src/api/tests/helpers.rs
+++ b/src/api/tests/helpers.rs
@@ -337,7 +337,7 @@ impl GitFileOps for MockGitInfo {
     }
 
     fn branch_tip(&self, _branch: &Option<String>) -> Result<ObjectId, GitFileOpsError> {
-        Err(GitFileOpsError::BranchNotFound("mock".to_string()))
+        Err(GitFileOpsError::LocalBranchNotFound("mock".to_string()))
     }
 
     fn file_touching_commits(

--- a/src/api/tests/helpers.rs
+++ b/src/api/tests/helpers.rs
@@ -230,6 +230,10 @@ impl GitRepository for MockGitInfo {
         &self.repo
     }
 
+    fn remote_name(&self) -> &str {
+        "origin"
+    }
+
     fn path(&self) -> &Path {
         Path::new(".")
     }

--- a/src/api/types/responses.rs
+++ b/src/api/types/responses.rs
@@ -319,6 +319,16 @@ pub struct BlockingQCItemWithStatus {
 pub struct BlockingQCError {
     pub issue_number: u64,
     pub error: String,
+    pub kind: IssueStatusErrorKind,
+    /// Title of the QC'd file, when known. Absent for fetch-failed errors
+    /// since we never retrieved the issue body. Present for processing
+    /// failures (incl. `BranchNotLocal`) since the issue itself was fetched.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_name: Option<String>,
+    /// Set when `kind == BranchNotLocal` — the branch ref that needs to be
+    /// fetched / checked out locally so the UI can offer a copy-pasteable fix.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
 }
 
 impl From<(u64, GitHubApiError)> for BlockingQCError {
@@ -326,6 +336,9 @@ impl From<(u64, GitHubApiError)> for BlockingQCError {
         Self {
             issue_number: value.0,
             error: value.1.to_string(),
+            kind: IssueStatusErrorKind::FetchFailed,
+            file_name: None,
+            branch: None,
         }
     }
 }
@@ -418,11 +431,14 @@ impl From<CreateResult> for CreateIssueResponse {
 }
 
 /// Error kind for batch issue status.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum IssueStatusErrorKind {
     FetchFailed,
     ProcessingFailed,
+    /// The issue's branch ref isn't reachable locally — the user likely needs
+    /// to `git checkout` it once to populate the local ref.
+    BranchNotLocal,
 }
 
 /// Error entry for batch issue status.
@@ -431,6 +447,9 @@ pub struct IssueStatusError {
     pub issue_number: u64,
     pub kind: IssueStatusErrorKind,
     pub error: String,
+    /// Set when `kind == BranchNotLocal`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
 }
 
 /// Envelope response for batch issue status.
@@ -560,6 +579,9 @@ pub struct ConfigurationStatusResponse {
 pub struct RepoInfoResponse {
     pub owner: String,
     pub repo: String,
+    /// Name of the user's default remote (almost always `"origin"`, but
+    /// configurable via `git clone --origin <name>` or rename).
+    pub remote: String,
     pub branch: String,
     pub local_commit: String,
     pub remote_commit: String,
@@ -706,6 +728,7 @@ impl RepoInfoResponse {
     ) -> Result<Self, ApiError> {
         let owner = git_info.owner().to_string();
         let repo = git_info.repo().to_string();
+        let remote = git_info.remote_name().to_string();
 
         // Async GitHub call — non-fatal, falls back to None
         let current_user = git_info.get_current_user().await.ok().flatten();
@@ -740,6 +763,7 @@ impl RepoInfoResponse {
         Ok(Self {
             owner,
             repo,
+            remote,
             branch,
             local_commit,
             remote_commit,

--- a/src/approve.rs
+++ b/src/approve.rs
@@ -580,7 +580,7 @@ mod tests {
         }
 
         fn branch_tip(&self, _branch: &Option<String>) -> Result<ObjectId, GitFileOpsError> {
-            Err(GitFileOpsError::BranchNotFound("mock".to_string()))
+            Err(GitFileOpsError::LocalBranchNotFound("mock".to_string()))
         }
 
         fn file_touching_commits(

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -191,7 +191,7 @@ mod tests {
         }
 
         fn branch_tip(&self, _branch: &Option<String>) -> Result<ObjectId, GitFileOpsError> {
-            Err(GitFileOpsError::BranchNotFound("mock".to_string()))
+            Err(GitFileOpsError::LocalBranchNotFound("mock".to_string()))
         }
 
         fn file_touching_commits(

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -994,6 +994,10 @@ Second Checklist:
                 &self.repo
             }
 
+            fn remote_name(&self) -> &str {
+                "origin"
+            }
+
             fn path(&self) -> &std::path::Path {
                 std::path::Path::new(".")
             }

--- a/src/create.rs
+++ b/src/create.rs
@@ -1421,7 +1421,7 @@ mod tests {
         }
 
         fn branch_tip(&self, _branch: &Option<String>) -> Result<ObjectId, GitFileOpsError> {
-            Err(GitFileOpsError::BranchNotFound("mock".to_string()))
+            Err(GitFileOpsError::LocalBranchNotFound("mock".to_string()))
         }
 
         fn file_touching_commits(

--- a/src/git/action.rs
+++ b/src/git/action.rs
@@ -10,9 +10,9 @@ pub trait GitCli {
 
     fn remote(&self, path: &Path) -> Result<Url, GitCliError>;
 
-    /// Fetch from origin. Returns whether any refs changed.
+    /// Fetch from the named remote. Returns whether any refs changed.
     /// Sets GIT_TERMINAL_PROMPT=0 to prevent blocking credential prompts.
-    fn fetch(&self, path: &Path) -> Result<bool, GitCliError>;
+    fn fetch(&self, path: &Path, remote_name: &str) -> Result<bool, GitCliError>;
 
     /// Stash changes for a single file path.
     fn stash_file(
@@ -65,8 +65,8 @@ impl<T: GitCli + ?Sized> GitCli for &T {
         (**self).remote(path)
     }
 
-    fn fetch(&self, path: &Path) -> Result<bool, GitCliError> {
-        (**self).fetch(path)
+    fn fetch(&self, path: &Path, remote_name: &str) -> Result<bool, GitCliError> {
+        (**self).fetch(path, remote_name)
     }
 
     fn stash_file(
@@ -154,11 +154,11 @@ impl GitCli for GitCommand {
         })
     }
 
-    fn fetch(&self, path: &Path) -> Result<bool, GitCliError> {
-        log::debug!("Fetching from origin in {}", path.display());
+    fn fetch(&self, path: &Path, remote_name: &str) -> Result<bool, GitCliError> {
+        log::debug!("Fetching from {} in {}", remote_name, path.display());
 
         let output = std::process::Command::new("git")
-            .args(["-C", &path.to_string_lossy(), "fetch", "origin"])
+            .args(["-C", &path.to_string_lossy(), "fetch", remote_name])
             .env("GIT_TERMINAL_PROMPT", "0")
             .output()?;
 

--- a/src/git/file_ops.rs
+++ b/src/git/file_ops.rs
@@ -214,9 +214,23 @@ impl GitFileOps for GitInfo {
         file: &Path,
     ) -> Result<HashSet<String>, GitFileOpsError> {
         use crate::git::action::{GitCli as _, GitCommand};
+        let branch_name = branch.clone();
         GitCommand
             .file_touching_commits(&self.repository_path, branch, file)
-            .map_err(|e| GitFileOpsError::BranchLookupFailed(e.to_string()))
+            .map_err(|e| {
+                let msg = e.to_string();
+                // git emits `fatal: bad revision '<ref>'` when asked about a
+                // ref that doesn't exist locally. In that case we know which
+                // branch was missing — surface it as the structured variant
+                // so the UI can offer the copy-pasteable fix instead of a
+                // raw "lookup failed" message with no suggestion.
+                if let Some(name) = branch_name {
+                    if msg.contains("bad revision") {
+                        return GitFileOpsError::LocalBranchNotFound(name);
+                    }
+                }
+                GitFileOpsError::BranchLookupFailed(msg)
+            })
     }
 
     fn authors(&self, file: &Path) -> Result<Vec<GitAuthor>, GitFileOpsError> {

--- a/src/git/file_ops.rs
+++ b/src/git/file_ops.rs
@@ -56,8 +56,15 @@ pub enum GitFileOpsError {
     BlobError(gix::object::try_into::Error),
     #[error("Failed to decode file content: {0:?}")]
     EncodingError(PathBuf),
-    #[error("Branch not found: {0}")]
-    BranchNotFound(String),
+    /// The named branch ref isn't reachable locally — the user likely needs
+    /// to fetch / track it before this tool can read its history.
+    #[error("Branch '{0}' is not checked out locally")]
+    LocalBranchNotFound(String),
+    /// A git operation related to branch lookup failed for a reason other than
+    /// a missing local ref (merge analysis, ancestry walk, etc.). The string
+    /// is a diagnostic message, not a branch name.
+    #[error("Branch lookup failed: {0}")]
+    BranchLookupFailed(String),
     #[error("Failed to get HEAD ID: {0}")]
     HeadIdError(gix::reference::head_id::Error),
     #[error("Failed to access repository: {0}")]
@@ -122,7 +129,7 @@ impl GitFileOps for GitInfo {
             let branch_ref_name = format!("refs/heads/{}", branch_name);
             let branch_ref = repo
                 .find_reference(&branch_ref_name)
-                .map_err(|_| GitFileOpsError::BranchNotFound(branch_name.clone()))?;
+                .map_err(|_| GitFileOpsError::LocalBranchNotFound(branch_name.clone()))?;
             branch_ref.id()
         } else {
             // Use HEAD as default
@@ -192,7 +199,7 @@ impl GitFileOps for GitInfo {
             let branch_ref_name = format!("refs/heads/{}", branch_name);
             let branch_ref = repo
                 .find_reference(&branch_ref_name)
-                .map_err(|_| GitFileOpsError::BranchNotFound(branch_name.clone()))?;
+                .map_err(|_| GitFileOpsError::LocalBranchNotFound(branch_name.clone()))?;
             Ok(branch_ref.id().detach())
         } else {
             repo.head_id()
@@ -209,7 +216,7 @@ impl GitFileOps for GitInfo {
         use crate::git::action::{GitCli as _, GitCommand};
         GitCommand
             .file_touching_commits(&self.repository_path, branch, file)
-            .map_err(|e| GitFileOpsError::BranchNotFound(e.to_string()))
+            .map_err(|e| GitFileOpsError::BranchLookupFailed(e.to_string()))
     }
 
     fn authors(&self, file: &Path) -> Result<Vec<GitAuthor>, GitFileOpsError> {
@@ -489,12 +496,12 @@ fn find_merged_into_branch(
     target_commit: &gix::ObjectId,
 ) -> Result<Option<String>, GitFileOpsError> {
     let merge_commits = git_info.get_all_merge_commits().map_err(|e| {
-        GitFileOpsError::BranchNotFound(format!("Failed to get merge commits: {}", e))
+        GitFileOpsError::BranchLookupFailed(format!("Failed to get merge commits: {}", e))
     })?;
 
     for merge_commit in merge_commits {
         let parents = git_info.get_commit_parents(&merge_commit).map_err(|e| {
-            GitFileOpsError::BranchNotFound(format!("Failed to get commit parents: {}", e))
+            GitFileOpsError::BranchLookupFailed(format!("Failed to get commit parents: {}", e))
         })?;
 
         if parents.len() >= 2 {
@@ -503,13 +510,13 @@ fn find_merged_into_branch(
 
             // Check if target_commit is ancestor of parent2 (the merged-in branch)
             if git_info.is_ancestor(target_commit, &parent2).map_err(|e| {
-                GitFileOpsError::BranchNotFound(format!("Failed to check ancestry: {}", e))
+                GitFileOpsError::BranchLookupFailed(format!("Failed to check ancestry: {}", e))
             })? {
                 // Find branches that contain the merge commit
                 let candidate_branches = git_info
                     .get_branches_containing_commit(&merge_commit)
                     .map_err(|e| {
-                        GitFileOpsError::BranchNotFound(format!(
+                        GitFileOpsError::BranchLookupFailed(format!(
                             "Failed to get branches containing commit: {}",
                             e
                         ))
@@ -550,7 +557,7 @@ pub fn get_commits_robust(
             log::debug!("Found {} commits for branch {:?}", commits.len(), branch);
             return Ok(commits);
         }
-        Err(GitFileOpsError::BranchNotFound(_)) if branch.is_some() => {
+        Err(GitFileOpsError::LocalBranchNotFound(_)) if branch.is_some() => {
             log::debug!(
                 "Branch {:?} not found locally, searching for merged commits",
                 branch
@@ -598,7 +605,7 @@ pub fn get_commits_robust(
             git_info
                 .get_branches_containing_commit(commit)
                 .map_err(|e| {
-                    GitFileOpsError::BranchNotFound(format!(
+                    GitFileOpsError::BranchLookupFailed(format!(
                         "Failed to get branches containing commit: {}",
                         e
                     ))
@@ -636,12 +643,11 @@ pub fn get_commits_robust(
 
     // Final fallback: return error that branch couldn't be found
     if let Some(branch_name) = branch {
-        Err(GitFileOpsError::BranchNotFound(format!(
-            "Could not find branch '{}' or determine alternative branch from commit",
-            branch_name
-        )))
+        // We know the branch name — surface it as a structured "not checked
+        // out locally" so the UI can offer a copy-pasteable fix.
+        Err(GitFileOpsError::LocalBranchNotFound(branch_name.clone()))
     } else {
-        Err(GitFileOpsError::BranchNotFound(
+        Err(GitFileOpsError::BranchLookupFailed(
             "Could not determine branch from commit".to_string(),
         ))
     }
@@ -821,8 +827,8 @@ mod tests {
                         message: message.clone(),
                     })
                     .collect()),
-                Some(Err(GitFileOpsError::BranchNotFound(branch_name))) => {
-                    Err(GitFileOpsError::BranchNotFound(branch_name.clone()))
+                Some(Err(GitFileOpsError::LocalBranchNotFound(branch_name))) => {
+                    Err(GitFileOpsError::LocalBranchNotFound(branch_name.clone()))
                 }
                 Some(Err(_e)) => Err(GitFileOpsError::AuthorNotFound(PathBuf::from("test"))), // Fallback error for testing
                 None => Ok(Vec::new()),
@@ -835,8 +841,8 @@ mod tests {
                 Some(Ok(commits)) => commits
                     .first()
                     .map(|(id, _)| *id)
-                    .ok_or_else(|| GitFileOpsError::BranchNotFound("empty branch".to_string())),
-                _ => Err(GitFileOpsError::BranchNotFound(
+                    .ok_or_else(|| GitFileOpsError::LocalBranchNotFound("empty branch".to_string())),
+                _ => Err(GitFileOpsError::LocalBranchNotFound(
                     branch.clone().unwrap_or_default(),
                 )),
             }
@@ -939,7 +945,7 @@ mod tests {
             // Original branch fails
             .with_file_commits_result(
                 Some(branch.to_string()),
-                Err(GitFileOpsError::BranchNotFound(branch.to_string())),
+                Err(GitFileOpsError::LocalBranchNotFound(branch.to_string())),
             )
             // Merge detection finds the target branch
             .with_merge_commits(vec![merge_commit])
@@ -977,7 +983,7 @@ mod tests {
             // Original branch fails
             .with_file_commits_result(
                 Some(branch.to_string()),
-                Err(GitFileOpsError::BranchNotFound(branch.to_string())),
+                Err(GitFileOpsError::LocalBranchNotFound(branch.to_string())),
             )
             // No merge commits found
             .with_merge_commits(vec![])
@@ -1017,7 +1023,7 @@ mod tests {
             // Original branch fails
             .with_file_commits_result(
                 Some(branch.to_string()),
-                Err(GitFileOpsError::BranchNotFound(branch.to_string())),
+                Err(GitFileOpsError::LocalBranchNotFound(branch.to_string())),
             )
             // No merge commits found
             .with_merge_commits(vec![])
@@ -1033,7 +1039,7 @@ mod tests {
         );
 
         // Should fail when no branch can be found
-        assert!(matches!(result, Err(GitFileOpsError::BranchNotFound(_))));
+        assert!(matches!(result, Err(GitFileOpsError::LocalBranchNotFound(_))));
     }
 
     #[tokio::test]
@@ -1044,7 +1050,7 @@ mod tests {
 
         let git_info = RobustMockGitInfo::new().with_file_commits_result(
             Some(branch.to_string()),
-            Err(GitFileOpsError::BranchNotFound(branch.to_string())),
+            Err(GitFileOpsError::LocalBranchNotFound(branch.to_string())),
         );
 
         let result = get_commits_robust(
@@ -1056,7 +1062,7 @@ mod tests {
         );
 
         // Should fail since no branches can be found and all fallbacks fail
-        assert!(matches!(result, Err(GitFileOpsError::BranchNotFound(_))));
+        assert!(matches!(result, Err(GitFileOpsError::LocalBranchNotFound(_))));
     }
 
     #[tokio::test]
@@ -1098,7 +1104,7 @@ mod tests {
             // Original branch fails
             .with_file_commits_result(
                 Some(branch.to_string()),
-                Err(GitFileOpsError::BranchNotFound(branch.to_string())),
+                Err(GitFileOpsError::LocalBranchNotFound(branch.to_string())),
             )
             // Multiple merge commits
             .with_merge_commits(vec![merge_commit1, merge_commit2])

--- a/src/git/file_ops.rs
+++ b/src/git/file_ops.rs
@@ -852,10 +852,9 @@ mod tests {
         fn branch_tip(&self, branch: &Option<String>) -> Result<ObjectId, GitFileOpsError> {
             // Return the first commit of this branch as its tip
             match self.file_commits_responses.get(branch) {
-                Some(Ok(commits)) => commits
-                    .first()
-                    .map(|(id, _)| *id)
-                    .ok_or_else(|| GitFileOpsError::LocalBranchNotFound("empty branch".to_string())),
+                Some(Ok(commits)) => commits.first().map(|(id, _)| *id).ok_or_else(|| {
+                    GitFileOpsError::LocalBranchNotFound("empty branch".to_string())
+                }),
                 _ => Err(GitFileOpsError::LocalBranchNotFound(
                     branch.clone().unwrap_or_default(),
                 )),
@@ -1053,7 +1052,10 @@ mod tests {
         );
 
         // Should fail when no branch can be found
-        assert!(matches!(result, Err(GitFileOpsError::LocalBranchNotFound(_))));
+        assert!(matches!(
+            result,
+            Err(GitFileOpsError::LocalBranchNotFound(_))
+        ));
     }
 
     #[tokio::test]
@@ -1076,7 +1078,10 @@ mod tests {
         );
 
         // Should fail since no branches can be found and all fallbacks fail
-        assert!(matches!(result, Err(GitFileOpsError::LocalBranchNotFound(_))));
+        assert!(matches!(
+            result,
+            Err(GitFileOpsError::LocalBranchNotFound(_))
+        ));
     }
 
     #[tokio::test]

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -60,6 +60,11 @@ pub struct GitInfo {
     pub(crate) base_url: String,
     pub(crate) repository_path: PathBuf,
     pub(crate) auth_sources: AuthSources,
+    /// Name of the default remote in the user's local repo. Almost always
+    /// `"origin"` but git supports renaming (e.g. `git clone --origin upstream`)
+    /// and forks-of-forks workflows. Captured once at GitInfo construction so
+    /// callers don't have to reach for the gix Remote each time.
+    pub(crate) remote_name: String,
 }
 
 impl GitInfo {
@@ -77,6 +82,12 @@ impl GitInfo {
             .find_default_remote(gix::remote::Direction::Fetch)
             .ok_or(GitInfoError::NoRemote)?
             .map_err(GitInfoError::RemoteNotFound)?;
+
+        let remote_name = remote
+            .name()
+            .map(|n| n.as_bstr().to_string())
+            .unwrap_or_else(|| "origin".to_string());
+        log::debug!("Default remote name: {}", remote_name);
 
         let remote_url = remote
             .url(gix::remote::Direction::Fetch)
@@ -113,7 +124,12 @@ impl GitInfo {
             base_url: remote_info.url,
             repository_path: path.to_path_buf(),
             auth_sources,
+            remote_name,
         })
+    }
+
+    pub fn remote_name(&self) -> &str {
+        &self.remote_name
     }
 
     /// Get a repository instance (recreated for thread safety)

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -89,8 +89,8 @@ impl GitRepository for GitInfo {
             // Extract the branch name from refs/heads/<branch>
             if let Some(stripped) = name_str.strip_prefix("refs/heads/") {
                 return Ok(stripped.to_string());
-            } else if let Some(stripped) = name_str
-                .strip_prefix(&format!("refs/remotes/{}/", self.remote_name))
+            } else if let Some(stripped) =
+                name_str.strip_prefix(&format!("refs/remotes/{}/", self.remote_name))
             {
                 return Ok(stripped.to_string());
             } else {

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -47,6 +47,9 @@ pub trait GitRepository {
     /// Get the repository name
     fn repo(&self) -> &str;
 
+    /// Get the name of the user's default remote (typically "origin").
+    fn remote_name(&self) -> &str;
+
     /// Get the repository path on the filesystem
     fn path(&self) -> &Path;
 
@@ -86,7 +89,9 @@ impl GitRepository for GitInfo {
             // Extract the branch name from refs/heads/<branch>
             if let Some(stripped) = name_str.strip_prefix("refs/heads/") {
                 return Ok(stripped.to_string());
-            } else if let Some(stripped) = name_str.strip_prefix("refs/remotes/origin/") {
+            } else if let Some(stripped) = name_str
+                .strip_prefix(&format!("refs/remotes/{}/", self.remote_name))
+            {
                 return Ok(stripped.to_string());
             } else {
                 return Ok(name_str);
@@ -134,13 +139,17 @@ impl GitRepository for GitInfo {
         &self.repo
     }
 
+    fn remote_name(&self) -> &str {
+        &self.remote_name
+    }
+
     fn path(&self) -> &Path {
         &self.repository_path
     }
 
     fn fetch(&self) -> Result<bool, GitRepositoryError> {
         GitCommand
-            .fetch(&self.repository_path)
+            .fetch(&self.repository_path, &self.remote_name)
             .map_err(|e| GitRepositoryError::FetchError(e.to_string()))
     }
 

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -133,7 +133,10 @@ impl GitStatusOps for GitInfo {
         };
 
         // Try to find the upstream tracking branch
-        let upstream_ref_name = format!("refs/remotes/origin/{}", current_branch_name);
+        let upstream_ref_name = format!(
+            "refs/remotes/{}/{}",
+            self.remote_name, current_branch_name
+        );
         let upstream_ref = match repo.find_reference(&upstream_ref_name) {
             Ok(r) => r,
             Err(_) => {

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -133,10 +133,8 @@ impl GitStatusOps for GitInfo {
         };
 
         // Try to find the upstream tracking branch
-        let upstream_ref_name = format!(
-            "refs/remotes/{}/{}",
-            self.remote_name, current_branch_name
-        );
+        let upstream_ref_name =
+            format!("refs/remotes/{}/{}", self.remote_name, current_branch_name);
         let upstream_ref = match repo.find_reference(&upstream_ref_name) {
             Ok(r) => r,
             Err(_) => {

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -177,8 +177,7 @@ impl IssueThread {
             Some(branch.clone()),
             &file,
             disk_cache,
-        )
-        .map_err(IssueError::GitFileOpsError)?;
+        )?;
 
         // Also mark commits that touched any previously-known file names from ## File History.
         // This ensures commits made against the old filename are still flagged as file-changing.

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -665,8 +665,10 @@ pub fn file_history_section(events: &[FileRenameEvent]) -> String {
 pub enum IssueError {
     #[error(transparent)]
     GitHubApiError(#[from] GitHubApiError),
+    #[error("Branch '{0}' is not checked out locally")]
+    LocalBranchNotFound(String),
     #[error(transparent)]
-    GitFileOpsError(#[from] GitFileOpsError),
+    GitFileOpsError(GitFileOpsError),
     #[error("Initial commit not found in issue body")]
     InitialCommitNotFound,
     #[error("Branch not found in issue body")]
@@ -677,6 +679,15 @@ pub enum IssueError {
     CommitNotParseable(String),
     #[error("No commits found for file: {0}")]
     CommitNotFound(PathBuf),
+}
+
+impl From<GitFileOpsError> for IssueError {
+    fn from(e: GitFileOpsError) -> Self {
+        match e {
+            GitFileOpsError::LocalBranchNotFound(name) => IssueError::LocalBranchNotFound(name),
+            other => IssueError::GitFileOpsError(other),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -811,7 +822,7 @@ mod tests {
         }
 
         fn branch_tip(&self, _branch: &Option<String>) -> Result<ObjectId, GitFileOpsError> {
-            Err(GitFileOpsError::BranchNotFound("mock".to_string()))
+            Err(GitFileOpsError::LocalBranchNotFound("mock".to_string()))
         }
 
         fn file_touching_commits(

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -769,7 +769,7 @@ mod tests {
         }
 
         fn branch_tip(&self, _branch: &Option<String>) -> Result<ObjectId, GitFileOpsError> {
-            Err(GitFileOpsError::BranchNotFound("mock".to_string()))
+            Err(GitFileOpsError::LocalBranchNotFound("mock".to_string()))
         }
 
         fn file_touching_commits(

--- a/src/relevant_files.rs
+++ b/src/relevant_files.rs
@@ -300,7 +300,7 @@ mod tests {
                 .ok_or_else(|| GitFileOpsError::FileNotFoundAtCommit(file.to_path_buf()))
         }
         fn branch_tip(&self, _branch: &Option<String>) -> Result<ObjectId, GitFileOpsError> {
-            Err(GitFileOpsError::BranchNotFound("mock".to_string()))
+            Err(GitFileOpsError::LocalBranchNotFound("mock".to_string()))
         }
 
         fn file_touching_commits(

--- a/src/review.rs
+++ b/src/review.rs
@@ -181,6 +181,10 @@ mod tests {
             "repo"
         }
 
+        fn remote_name(&self) -> &str {
+            "origin"
+        }
+
         fn path(&self) -> &std::path::Path {
             std::path::Path::new(".")
         }
@@ -270,7 +274,7 @@ mod tests {
         }
 
         fn branch_tip(&self, _branch: &Option<String>) -> Result<ObjectId, GitFileOpsError> {
-            Err(GitFileOpsError::BranchNotFound("mock".to_string()))
+            Err(GitFileOpsError::LocalBranchNotFound("mock".to_string()))
         }
 
         fn file_touching_commits(

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -75,6 +75,11 @@ export interface BlockingQCItemWithStatus {
 export interface BlockingQCError {
   issue_number: number
   error: string
+  kind: IssueStatusErrorKind
+  /** Title of the QC'd file. Present for processing failures; absent when the issue itself failed to fetch. */
+  file_name?: string
+  /** Set when `kind === 'branch_not_local'` — the branch the user needs to check out. */
+  branch?: string
 }
 
 export interface BlockingQCStatus {
@@ -158,12 +163,14 @@ export async function postComment(issueNumber: number, request: CreateCommentReq
   return res.json()
 }
 
-export type IssueStatusErrorKind = 'fetch_failed' | 'processing_failed'
+export type IssueStatusErrorKind = 'fetch_failed' | 'processing_failed' | 'branch_not_local'
 
 export interface IssueStatusError {
   issue_number: number
   kind: IssueStatusErrorKind
   error: string
+  /** Set when `kind === 'branch_not_local'`. */
+  branch?: string
 }
 
 export interface BatchIssueStatusResponse {

--- a/ui/src/api/repo.ts
+++ b/ui/src/api/repo.ts
@@ -8,6 +8,8 @@ export type GitStatus = 'clean' | 'ahead' | 'behind' | 'diverged'
 export interface RepoInfo {
   owner: string
   repo: string
+  /** Name of the user's default remote (typically "origin"). */
+  remote: string
   branch: string
   local_commit: string
   remote_commit: string

--- a/ui/src/components/ArchiveTab.tsx
+++ b/ui/src/components/ArchiveTab.tsx
@@ -15,7 +15,6 @@ import {
   useCombobox,
 } from '@mantine/core'
 import {
-  IconAlertCircle,
   IconAlertTriangle,
   IconArrowBackUp,
   IconEye,
@@ -35,6 +34,7 @@ import {
 import { type ArchiveFileRequest, generateArchive } from '~/api/archive'
 import { useRepoInfo } from '~/api/repo'
 import { OpenPill } from './MilestoneFilter'
+import { StatusErrorDisplay } from './StatusErrorDisplay'
 import { ResizableSidebar } from './ResizableSidebar'
 import { type FileResolution, FileResolveModal } from './FileResolveModal'
 import { RelevantFilesList } from './RelevantFilesList'
@@ -1201,15 +1201,6 @@ function ArchiveMilestoneCard({
   const bgColor = isRed ? '#ffe3e3' : isYellow ? '#fff3bf' : '#d7e7d3'
   const borderColor = isRed ? '#ff8787' : isYellow ? '#fcc419' : '#aacca6'
 
-  const errorLines =
-    statusInfo.statusErrors.length > 0 ? (
-      <div>
-        {statusInfo.statusErrors.map((e) => (
-          <div key={e.issue_number}>#{e.issue_number}: {e.error}</div>
-        ))}
-      </div>
-    ) : null
-
   return (
     <div style={{
       display: 'flex',
@@ -1234,13 +1225,8 @@ function ArchiveMilestoneCard({
               <IconExclamationMark data-testid="list-error-indicator" size={14} color="#c92a2a" style={{ flexShrink: 0 }} />
             </Tooltip>
           )}
-          {statusInfo.statusErrorCount > 0 && errorLines && (
-            <Tooltip label={errorLines} withArrow multiline>
-              <span data-testid="status-error-count" style={{ color: '#c92a2a', display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0 }}>
-                <IconAlertCircle size={14} />
-                {statusInfo.statusErrorCount}
-              </span>
-            </Tooltip>
+          {statusInfo.statusErrorCount > 0 && (
+            <StatusErrorDisplay errors={statusInfo.statusErrors} variant="icon-red" />
           )}
           {isYellow && (
             <Tooltip

--- a/ui/src/components/FileResolveModal.tsx
+++ b/ui/src/components/FileResolveModal.tsx
@@ -33,6 +33,7 @@ import {
   issueStatusBatcher,
   useAllMilestoneIssues,
 } from '~/api/issues'
+import { StatusErrorDisplay } from './StatusErrorDisplay'
 import { useMilestones } from '~/api/milestones'
 import { type BranchCommit, fetchBranchCommits } from '~/api/commits'
 import { CommitSlider } from './CommitSlider'
@@ -493,14 +494,18 @@ function CommitIssueStep({
                 </div>
               )
             })}
-            {statusErrors.map(err => (
-              <Alert key={err.issue_number} color="red" p="xs">
-                <Text size="xs">Issue #{err.issue_number}: {err.error}</Text>
-              </Alert>
-            ))}
+            {statusErrors.length > 0 && <FileResolveStatusErrors errors={statusErrors} />}
           </Stack>
         </Tabs.Panel>
       </Tabs>
     </Stack>
+  )
+}
+
+function FileResolveStatusErrors({ errors }: { errors: IssueStatusError[] }) {
+  return (
+    <Alert color="red" p="xs">
+      <StatusErrorDisplay errors={errors} variant="inline-list" />
+    </Alert>
   )
 }

--- a/ui/src/components/IssueDetailModal.tsx
+++ b/ui/src/components/IssueDetailModal.tsx
@@ -28,6 +28,7 @@ import { wrapInGithubStyles } from '~/utils/github'
 import { STATUS_LANE_COLOR } from '~/utils/statusColors'
 import { useChecklistDisplayName } from '~/api/configuration'
 import { capitalize } from '~/utils/displayName'
+import { StatusErrorDisplay } from './StatusErrorDisplay'
 
 // Commit status dot colors (rendered oldest→newest, lowest→highest)
 const STATUS_DOT_COLORS: Record<string, string> = {
@@ -510,11 +511,12 @@ function StatusCard({ status }: { status: IssueStatusResponse }) {
                 ✗ {item.file_name} (#{item.issue_number}) — {item.status}
               </Text>
             ))}
-            {blocking_qc_status.errors.map((item) => (
-              <Text key={item.issue_number} size="sm" c="red">
-                ! #{item.issue_number}: {item.error}
-              </Text>
-            ))}
+            {blocking_qc_status.errors.length > 0 && (
+              <StatusErrorDisplay
+                errors={blocking_qc_status.errors}
+                variant="inline-list"
+              />
+            )}
           </Stack>
         )}
       </Stack>
@@ -951,11 +953,9 @@ function ApproveTab({ status, onStatusUpdate }: { status: IssueStatusResponse; o
                 {item.file_name} (#{item.issue_number}) — {item.status}
               </Text>
             ))}
-            {bqs.errors.map((item) => (
-              <Text key={item.issue_number} size="xs" c="red">
-                #{item.issue_number}: {item.error}
-              </Text>
-            ))}
+            {bqs.errors.length > 0 && (
+              <StatusErrorDisplay errors={bqs.errors} variant="inline-list" />
+            )}
           </Stack>
           <Checkbox
             mt="xs"

--- a/ui/src/components/IssueDetailModal.tsx
+++ b/ui/src/components/IssueDetailModal.tsx
@@ -460,13 +460,34 @@ function StatusCard({ status }: { status: IssueStatusResponse }) {
       style={{ maxWidth: 380, marginLeft: 'auto', marginRight: 'auto', width: '100%' }}
     >
       <Stack gap="xs">
-        <div style={{ textAlign: 'center', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 4 }}>
-          <Anchor href={issue.html_url} target="_blank" fw={700}>
+        <div
+          style={{
+            textAlign: 'center',
+            display: 'flex',
+            alignItems: 'baseline',
+            justifyContent: 'center',
+            gap: 4,
+            // File-path titles have no spaces; without `anywhere` they
+            // overflow the card. With it, the browser will break inside the
+            // path (e.g. on `/`) only when needed to fit the available width.
+            overflowWrap: 'anywhere',
+            minWidth: 0,
+          }}
+        >
+          <Anchor
+            href={issue.html_url}
+            target="_blank"
+            fw={700}
+            style={{ overflowWrap: 'anywhere', wordBreak: 'break-word' }}
+          >
             {issue.title}
           </Anchor>
           {status.dirty && (
             <Tooltip label="This file has uncommitted local changes" withArrow position="top">
-              <span data-testid="dirty-indicator" style={{ color: '#c92a2a', display: 'flex', lineHeight: 1 }}>
+              <span
+                data-testid="dirty-indicator"
+                style={{ color: '#c92a2a', display: 'inline-flex', lineHeight: 1, flexShrink: 0 }}
+              >
                 <IconAsterisk size={14} stroke={3} />
               </span>
             </Tooltip>

--- a/ui/src/components/MilestoneFilter.tsx
+++ b/ui/src/components/MilestoneFilter.tsx
@@ -9,15 +9,11 @@ import {
   Tooltip,
   useCombobox,
 } from '@mantine/core'
-import {
-  IconAlertCircle,
-  IconAlertTriangle,
-  IconExclamationMark,
-  IconX,
-} from '@tabler/icons-react'
+import { IconExclamationMark, IconX } from '@tabler/icons-react'
 import { useState } from 'react'
 import { useMilestones, type Milestone } from '~/api/milestones'
 import { type MilestoneStatusInfo } from '~/api/issues'
+import { StatusErrorDisplay } from './StatusErrorDisplay'
 
 interface Props {
   selected: number[]
@@ -202,14 +198,6 @@ function SelectedMilestoneCard({
   const bgColor = isRed ? '#ffe3e3' : isYellow ? '#fff3bf' : '#d7e7d3'
   const borderColor = isRed ? '#ff8787' : isYellow ? '#fcc419' : '#aacca6'
 
-  const errorLines = statusInfo.statusErrors.length > 0 ? (
-    <div>
-      {statusInfo.statusErrors.map((e) => (
-        <div key={e.issue_number}>#{e.issue_number}: {e.error}</div>
-      ))}
-    </div>
-  ) : null
-
   return (
     <div style={{
       display: 'flex',
@@ -230,21 +218,11 @@ function SelectedMilestoneCard({
               <IconExclamationMark size={14} color="#c92a2a" style={{ flexShrink: 0 }} />
             </Tooltip>
           )}
-          {isAllFailed && errorLines && (
-            <Tooltip label={errorLines} withArrow multiline>
-              <span style={{ color: '#c92a2a', display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0 }}>
-                <IconAlertCircle size={14} />
-                {statusInfo.statusErrorCount}
-              </span>
-            </Tooltip>
+          {isAllFailed && (
+            <StatusErrorDisplay errors={statusInfo.statusErrors} variant="icon-red" />
           )}
-          {isPartial && errorLines && (
-            <Tooltip label={errorLines} withArrow multiline>
-              <span data-testid="partial-warning" style={{ color: '#e67700', display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0 }}>
-                <IconAlertTriangle size={14} />
-                {statusInfo.statusErrorCount}
-              </span>
-            </Tooltip>
+          {isPartial && (
+            <StatusErrorDisplay errors={statusInfo.statusErrors} variant="icon-yellow" />
           )}
         </div>
         <Text size="xs" c="dimmed">

--- a/ui/src/components/RecordTab.tsx
+++ b/ui/src/components/RecordTab.tsx
@@ -19,7 +19,6 @@ import {
   Droppable,
 } from '@hello-pangea/dnd'
 import {
-  IconAlertCircle,
   IconAlertTriangle,
   IconArrowBackUp,
   IconChevronDown,
@@ -37,6 +36,7 @@ import { type RecordRequest, generateRecord, previewRecord } from '~/api/record'
 import { useRepoInfo } from '~/api/repo'
 import { type MilestoneStatusInfo, useMilestoneIssues } from '~/api/issues'
 import { OpenPill } from './MilestoneFilter'
+import { StatusErrorDisplay } from './StatusErrorDisplay'
 import { ResizableSidebar } from './ResizableSidebar'
 import { AddContextFileModal } from './AddContextFileModal'
 import { ToggleField } from './ToggleField'
@@ -821,15 +821,6 @@ function RecordMilestoneCard({
   const bgColor = isRed ? '#ffe3e3' : isYellow ? '#fff3bf' : '#d7e7d3'
   const borderColor = isRed ? '#ff8787' : isYellow ? '#fcc419' : '#aacca6'
 
-  const errorLines =
-    statusInfo.statusErrors.length > 0 ? (
-      <div>
-        {statusInfo.statusErrors.map((e) => (
-          <div key={e.issue_number}>#{e.issue_number}: {e.error}</div>
-        ))}
-      </div>
-    ) : null
-
   return (
     <div style={{
       display: 'flex',
@@ -854,13 +845,8 @@ function RecordMilestoneCard({
               <IconExclamationMark data-testid="list-error-indicator" size={14} color="#c92a2a" style={{ flexShrink: 0 }} />
             </Tooltip>
           )}
-          {statusInfo.statusErrorCount > 0 && errorLines && (
-            <Tooltip label={errorLines} withArrow multiline>
-              <span data-testid="status-error-count" style={{ color: '#c92a2a', display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0 }}>
-                <IconAlertCircle size={14} />
-                {statusInfo.statusErrorCount}
-              </span>
-            </Tooltip>
+          {statusInfo.statusErrorCount > 0 && (
+            <StatusErrorDisplay errors={statusInfo.statusErrors} variant="icon-red" />
           )}
           {isYellow && (
             <Tooltip

--- a/ui/src/components/StatusErrorDisplay.tsx
+++ b/ui/src/components/StatusErrorDisplay.tsx
@@ -1,0 +1,382 @@
+import { useState } from 'react'
+import {
+  ActionIcon,
+  Anchor,
+  Code,
+  CopyButton,
+  Divider,
+  Popover,
+  Stack,
+  Text,
+  Tooltip,
+} from '@mantine/core'
+import {
+  IconAlertCircle,
+  IconAlertTriangle,
+  IconCheck,
+  IconChevronDown,
+  IconChevronUp,
+  IconCopy,
+} from '@tabler/icons-react'
+import type { IssueStatusError, BlockingQCError } from '~/api/issues'
+import { useRepoInfo } from '~/api/repo'
+
+// Both error shapes share the fields we care about. Accept either.
+type AnyStatusError = Pick<IssueStatusError | BlockingQCError, 'issue_number' | 'error'> & {
+  kind?: IssueStatusError['kind']
+  branch?: string
+  file_name?: string
+}
+
+type Variant = 'icon-red' | 'icon-yellow' | 'inline-list'
+
+interface Props {
+  errors: AnyStatusError[]
+  variant: Variant
+}
+
+const FALLBACK_REMOTE = 'origin'
+
+interface BranchGroup {
+  branch: string
+  issues: number[]
+}
+
+function shellQuote(s: string): string {
+  // POSIX-safe single-quote wrap. Embedded single quotes become '\''.
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+// Build a copy-pasteable command that creates the missing local branch refs
+// without changing the working tree:
+//   git fetch <remote>
+//     && git branch --track 'foo' <remote>/foo
+//     && git branch --track 'bar' <remote>/bar
+//
+// `--track` only sets up the local ref + upstream tracking — it does not
+// switch the checkout — so we don't need to checkout back afterwards. The
+// remote name comes from /api/repo (gix's find_default_remote).
+function buildCheckoutCommand(branches: string[], remote: string): string | null {
+  if (branches.length === 0) return null
+  const parts = [`git fetch ${remote}`]
+  for (const b of branches) {
+    // We single-quote the local ref to handle spaces / shell-specials.
+    // The `<remote>/<branch>` ref name uses the remote as parsed by gix —
+    // it should be a plain identifier, but quote defensively.
+    parts.push(`git branch --track ${shellQuote(b)} ${remote}/${b}`)
+  }
+  return parts.join(' && ')
+}
+
+// Extract the missing-branch name from an error. Falls back to a regex match
+// on the legacy `"Branch not found: <name>"` string when `kind`/`branch` aren't
+// populated (rolling-deploy of an older backend).
+function extractMissingBranch(e: AnyStatusError): string | null {
+  if (e.kind === 'branch_not_local') return e.branch ?? null
+  const m = /^Branch not found: (.+)$/.exec(e.error)
+  return m ? m[1] : null
+}
+
+function groupBranchErrors(errors: AnyStatusError[]): BranchGroup[] {
+  const map = new Map<string, number[]>()
+  for (const e of errors) {
+    const branch = extractMissingBranch(e)
+    if (branch === null) continue
+    const list = map.get(branch) ?? []
+    list.push(e.issue_number)
+    map.set(branch, list)
+  }
+  return [...map.entries()]
+    .map(([branch, issues]) => ({ branch, issues: [...new Set(issues)].sort((a, b) => a - b) }))
+    .sort((a, b) => a.branch.localeCompare(b.branch))
+}
+
+function partition(errors: AnyStatusError[]): { branchErrors: AnyStatusError[]; otherErrors: AnyStatusError[] } {
+  const branchErrors: AnyStatusError[] = []
+  const otherErrors: AnyStatusError[] = []
+  for (const e of errors) {
+    if (extractMissingBranch(e) !== null) branchErrors.push(e)
+    else otherErrors.push(e)
+  }
+  return { branchErrors, otherErrors }
+}
+
+// ---------------------------------------------------------------------------
+// Tooltip-style summary list — always visible in the dropdown.
+// ---------------------------------------------------------------------------
+function ErrorSummaryList({ errors, dimmed }: { errors: AnyStatusError[]; dimmed?: boolean }) {
+  return (
+    <Stack gap={2}>
+      {errors.map((e) => (
+        <Text key={e.issue_number} size="xs" c={dimmed ? 'dimmed' : undefined}>
+          #{e.issue_number}: {e.error}
+        </Text>
+      ))}
+    </Stack>
+  )
+}
+
+// `! <file_name> (#<n>) — <error>` — matches the approved/not_approved
+// blocking-QC line format. Falls back to `#<n>: <error>` when there's no
+// file_name (e.g. when the issue body itself was never fetched).
+function InlineErrorLine({ error }: { error: AnyStatusError }) {
+  if (error.file_name) {
+    return (
+      <Text size="sm" c="red">
+        ! {error.file_name} (#{error.issue_number}) — {error.error}
+      </Text>
+    )
+  }
+  return (
+    <Text size="xs" c="red">
+      #{error.issue_number}: {error.error}
+    </Text>
+  )
+}
+
+// Inline label for the single-branch case, mirroring the approved/not_approved
+// format when we know the file: `<file_name> (#<n>) — branch isn't checked out`.
+function formatBranchInlineLabel(error: AnyStatusError): string {
+  const suffix = "branch isn't checked out locally"
+  if (error.file_name) {
+    return `${error.file_name} (#${error.issue_number}) — ${suffix}`
+  }
+  return `Branch isn't checked out locally (#${error.issue_number})`
+}
+
+// ---------------------------------------------------------------------------
+// Rich expanded section — branch list + copy-pasteable command.
+// Renders `null` when there are no branch_not_local errors.
+// ---------------------------------------------------------------------------
+function BranchFixSection({ branchErrors }: { branchErrors: AnyStatusError[] }) {
+  const { data: repoData } = useRepoInfo()
+  const remote = repoData?.remote ?? FALLBACK_REMOTE
+  const groups = groupBranchErrors(branchErrors)
+  if (groups.length === 0) return null
+  const branches = groups.map((g) => g.branch)
+  const command = buildCheckoutCommand(branches, remote)
+
+  return (
+    <Stack gap="xs">
+      <Text size="sm" fw={600}>These branches aren't checked out locally:</Text>
+      <Stack gap={2}>
+        {groups.map((g) => (
+          <Text key={g.branch} size="sm">
+            <Code>{g.branch}</Code>
+            {' — '}
+            {g.issues.map((n) => `#${n}`).join(', ')}
+          </Text>
+        ))}
+      </Stack>
+
+      {command && (
+        <>
+          <Text size="xs" c="dimmed">
+            Run this to create the missing local refs:
+          </Text>
+          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 6 }}>
+            <Code block style={{ flex: 1, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+              {command}
+            </Code>
+            {/* Stop click bubbling so copying doesn't toggle the expanded state. */}
+            <span onClick={(e) => e.stopPropagation()}>
+              <CopyButton value={command} timeout={1500}>
+                {({ copied, copy }) => (
+                  <Tooltip label={copied ? 'Copied' : 'Copy command'} withArrow>
+                    <ActionIcon
+                      variant="subtle"
+                      color={copied ? 'teal' : 'gray'}
+                      onClick={copy}
+                      aria-label="Copy command"
+                    >
+                      {copied ? <IconCheck size={16} /> : <IconCopy size={16} />}
+                    </ActionIcon>
+                  </Tooltip>
+                )}
+              </CopyButton>
+            </span>
+          </div>
+        </>
+      )}
+    </Stack>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Public component
+// ---------------------------------------------------------------------------
+export function StatusErrorDisplay({ errors, variant }: Props) {
+  // `expanded` controls whether the rich fix section is shown beneath the
+  // basic per-issue summary. It's also used to keep the icon-variant dropdown
+  // pinned open even when the user mouses out — otherwise clicking inside
+  // the dropdown to expand would cause a flicker as the hover popover closed.
+  const [expanded, setExpanded] = useState(false)
+  const [hoverOpen, setHoverOpen] = useState(false)
+  const [inlineOpen, setInlineOpen] = useState(false)
+
+  if (errors.length === 0) return null
+
+  const { branchErrors, otherErrors } = partition(errors)
+  const hasBranchErrors = branchErrors.length > 0
+
+  const toggleExpanded = (ev: React.MouseEvent) => {
+    if (!hasBranchErrors) return
+    ev.stopPropagation()
+    setExpanded((e) => !e)
+  }
+
+  // -------- inline-list variant (used inside IssueDetailModal etc.) --------
+  // Renders each error in the same shape as approved/not_approved blocking-QC
+  // entries: `! <file_name> (#<n>) — <error/label>`. branch_not_local errors
+  // get a clickable label that opens the fix popover.
+  if (variant === 'inline-list') {
+    return (
+      <Stack gap={2}>
+        {otherErrors.map((e) => (
+          <InlineErrorLine key={e.issue_number} error={e} />
+        ))}
+        {hasBranchErrors && (
+          <Popover
+            opened={inlineOpen}
+            onChange={setInlineOpen}
+            position="bottom-start"
+            shadow="md"
+            withArrow
+            withinPortal
+          >
+            <Popover.Target>
+              <Tooltip label="Click to show fix" withArrow position="top-start">
+                <Anchor
+                  component="button"
+                  type="button"
+                  size="sm"
+                  c="orange.7"
+                  fw={500}
+                  onClick={() => setInlineOpen((o) => !o)}
+                  style={{
+                    alignSelf: 'flex-start',
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: 6,
+                    textAlign: 'left',
+                  }}
+                >
+                  {/* Pin icon to first-line baseline; wrapped text aligns to
+                      the text column, not under the icon. */}
+                  <IconAlertTriangle
+                    size={14}
+                    style={{ flexShrink: 0, marginTop: 3 }}
+                  />
+                  <span>
+                    {branchErrors.length === 1
+                      ? formatBranchInlineLabel(branchErrors[0])
+                      : `${branchErrors.length} blocking QCs aren't checked out locally`}
+                  </span>
+                </Anchor>
+              </Tooltip>
+            </Popover.Target>
+            <Popover.Dropdown>
+              <BranchFixSection branchErrors={branchErrors} />
+            </Popover.Dropdown>
+          </Popover>
+        )}
+      </Stack>
+    )
+  }
+
+  // -------- icon variants — milestone-level surfaces ----------------------
+  const isRed = variant === 'icon-red'
+  const Icon = isRed ? IconAlertCircle : IconAlertTriangle
+  const color = isRed ? '#c92a2a' : '#e67700'
+  const ChevronIcon = expanded ? IconChevronUp : IconChevronDown
+
+  // The dropdown body. Always shows the basic per-issue list (the original
+  // tooltip content); when `expanded`, the rich fix section appears beneath.
+  // Clicking anywhere on the body toggles `expanded` (when there's a fix to
+  // show); the copy button stops propagation so it doesn't trigger toggle.
+  const dropdownContent = (
+    <div
+      onClick={toggleExpanded}
+      style={{
+        cursor: hasBranchErrors ? 'pointer' : 'default',
+        maxWidth: 520,
+      }}
+    >
+      <Stack gap="xs">
+        <ErrorSummaryList errors={errors} />
+        {hasBranchErrors && (
+          <>
+            <Divider />
+            {expanded ? (
+              <BranchFixSection branchErrors={branchErrors} />
+            ) : (
+              <Text
+                size="xs"
+                c="dimmed"
+                style={{ display: 'flex', alignItems: 'center', gap: 4 }}
+              >
+                <ChevronIcon size={12} />
+                Click to show fix
+              </Text>
+            )}
+          </>
+        )}
+      </Stack>
+    </div>
+  )
+
+  // `opened` is the OR of "user is hovering the trigger or dropdown" and
+  // "user clicked to expand". Hover is the cheap preview; clicking pins the
+  // popover so interacting with its contents (selecting text, hitting copy)
+  // doesn't dismiss it. When the user collapses again, hover regains control.
+  const opened = hoverOpen || expanded
+
+  const trigger = (
+    <span
+      data-testid={isRed ? 'status-error-count' : 'partial-warning'}
+      onClick={(ev) => {
+        if (!hasBranchErrors) return
+        ev.stopPropagation()
+        setExpanded((e) => !e)
+      }}
+      onMouseEnter={() => setHoverOpen(true)}
+      onMouseLeave={() => setHoverOpen(false)}
+      style={{
+        color,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 2,
+        flexShrink: 0,
+        cursor: hasBranchErrors ? 'pointer' : 'default',
+      }}
+    >
+      <Icon size={14} />
+      {errors.length}
+    </span>
+  )
+
+  return (
+    <Popover
+      opened={opened}
+      onChange={(o) => {
+        if (!o) {
+          setHoverOpen(false)
+          setExpanded(false)
+        }
+      }}
+      position="bottom"
+      shadow="md"
+      withArrow
+      withinPortal
+      closeOnClickOutside
+    >
+      <Popover.Target>{trigger}</Popover.Target>
+      <Popover.Dropdown
+        onMouseEnter={() => setHoverOpen(true)}
+        onMouseLeave={() => setHoverOpen(false)}
+      >
+        {dropdownContent}
+      </Popover.Dropdown>
+    </Popover>
+  )
+}

--- a/ui/tests/fixtures/index.ts
+++ b/ui/tests/fixtures/index.ts
@@ -15,6 +15,7 @@ import type { CreateIssueResponse } from '../../src/api/create'
 export const defaultRepoInfo: RepoInfo = {
   owner: 'test-owner',
   repo: 'test-repo',
+  remote: 'origin',
   branch: 'main',
   local_commit: 'abc1234',
   remote_commit: 'abc1234',


### PR DESCRIPTION
Based on some feedback, the most common reason an issue's status cannot be loaded is because the branch it is on is not locally checked out. The error messages communicated that there was an error about the branch, but did not communicate a solution very well. This PR address this by using tooltips to detail what the error is and then suggest a possible fix.

Additionally, it improves frontend, issue detail modal issue title wrapping