### PR TITLE
persist checklist state

### DIFF
--- a/ui/src/components/ChecklistTab.tsx
+++ b/ui/src/components/ChecklistTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Alert, Button, Group, Loader, Stack, Text, TextInput, Textarea, Tooltip } from '@mantine/core'
+import { Alert, Badge, Button, Group, Loader, Stack, Text, TextInput, Textarea, Tooltip } from '@mantine/core'
 import { fetchChecklists } from '~/api/checklists'
 import { useChecklistDisplayName } from '~/api/configuration'
 import { capitalize } from '~/utils/displayName'
@@ -12,9 +12,15 @@ export interface ChecklistDraft {
 
 interface TabEntry {
   key: string
+  isQueuedSnapshot?: boolean
+  // Editor-bound, modal-session-only. Mirrors keystrokes; survives tab switches.
+  draftName: string
+  draftContent: string
+  // Last persisted across modal opens (via onSaveCustom).
   savedName: string
   savedContent: string
-  originalName: string    // immutable API default — used by Reset
+  // Immutable API default; used by Reset for API-origin tabs.
+  originalName: string
   originalContent: string
 }
 
@@ -27,6 +33,8 @@ interface Props {
   /** Called when user saves a custom (non-API) tab; parent stores it across opens */
   onSaveCustom?: (tab: ChecklistDraft) => void
 }
+
+const QUEUED_SNAPSHOT_KEY = 'queued-snapshot'
 
 export function ChecklistTab({ onChange, onSelect, initialDraft, persistedCustomTabs, onSaveCustom }: Props) {
   const counter = useRef(0)
@@ -55,62 +63,64 @@ export function ChecklistTab({ onChange, onSelect, initialDraft, persistedCustom
 
         // Exclude "Custom" from the visible tab list — it's only used as the "+ New" seed
         const visible = data.filter((t) => t.name !== 'Custom')
-        const entries: TabEntry[] = visible.map((t, i) => ({
-          key: `api-${i}`,
-          savedName: t.name,
-          savedContent: t.content,
-          originalName: t.name,
-          originalContent: t.content,
-        }))
-
-        // Merge persisted saves into API tabs (overrides savedContent for edited API tabs),
-        // then append any persisted custom tabs whose names don't match an API tab.
         const apiNames = new Set(visible.map((t) => t.name))
         const persistedMap = new Map((persistedCustomTabs ?? []).map((t) => [t.name, t]))
-        const mergedEntries: TabEntry[] = entries.map((e) => {
-          const persisted = persistedMap.get(e.originalName)
-          return persisted ? { ...e, savedName: persisted.name, savedContent: persisted.content } : e
+
+        // API tabs, possibly with persisted-save overrides on saved fields.
+        const apiEntries: TabEntry[] = visible.map((t, i) => {
+          const persisted = persistedMap.get(t.name)
+          const savedName = persisted ? persisted.name : t.name
+          const savedContent = persisted ? persisted.content : t.content
+          return {
+            key: `api-${i}`,
+            draftName: savedName,
+            draftContent: savedContent,
+            savedName,
+            savedContent,
+            originalName: t.name,
+            originalContent: t.content,
+          }
         })
+
+        // Persisted custom (non-API) tabs.
         const extraEntries: TabEntry[] = (persistedCustomTabs ?? [])
           .filter((t) => !apiNames.has(t.name))
           .map((t, i) => ({
             key: `persisted-${i}`,
+            draftName: t.name,
+            draftContent: t.content,
             savedName: t.name,
             savedContent: t.content,
             originalName: t.name,
             originalContent: t.content,
           }))
-        const allEntries = [...mergedEntries, ...extraEntries]
 
-        setTabs(allEntries)
-        setLoading(false)
+        let allEntries: TabEntry[] = [...apiEntries, ...extraEntries]
 
-        // When editing, pre-select the matching tab (or create a custom one)
+        // Edit mode: prepend a queued-snapshot tab and activate it.
         if (initialDraft) {
-          const match = allEntries.find((e) => e.savedName === initialDraft.name)
-          if (match) {
-            setActiveKey(match.key)
-            setEditorName(match.savedName)
-            setEditorContent(match.savedContent)
-            onChange({ name: match.savedName, content: match.savedContent })
-          } else {
-            const customKey = 'edit-custom'
-            const customTab: TabEntry = {
-              key: customKey,
-              savedName: initialDraft.name,
-              savedContent: initialDraft.content,
-              originalName: initialDraft.name,
-              originalContent: initialDraft.content,
-            }
-            setTabs([...allEntries, customTab])
-            setActiveKey(customKey)
-            setEditorName(initialDraft.name)
-            setEditorContent(initialDraft.content)
-            onChange({ name: initialDraft.name, content: initialDraft.content })
+          const snapshotTab: TabEntry = {
+            key: QUEUED_SNAPSHOT_KEY,
+            isQueuedSnapshot: true,
+            draftName: initialDraft.name,
+            draftContent: initialDraft.content,
+            savedName: initialDraft.name,
+            savedContent: initialDraft.content,
+            originalName: initialDraft.name,
+            originalContent: initialDraft.content,
           }
+          allEntries = [snapshotTab, ...allEntries]
+          setTabs(allEntries)
+          setLoading(false)
+          setActiveKey(QUEUED_SNAPSHOT_KEY)
+          setEditorName(initialDraft.name)
+          setEditorContent(initialDraft.content)
+          onChange({ name: initialDraft.name, content: initialDraft.content })
           return
         }
 
+        setTabs(allEntries)
+        setLoading(false)
         // Fresh create: no tab selected, no editor rendered
         setActiveKey(null)
       })
@@ -124,18 +134,27 @@ export function ChecklistTab({ onChange, onSelect, initialDraft, persistedCustom
     const tab = entries.find((t) => t.key === key)
     if (!tab) return
     setActiveKey(key)
-    setEditorName(tab.savedName)
-    setEditorContent(tab.savedContent)
-    onChange({ name: tab.savedName, content: tab.savedContent })
+    setEditorName(tab.draftName)
+    setEditorContent(tab.draftContent)
+    onChange({ name: tab.draftName, content: tab.draftContent })
+  }
+
+  function updateActiveDraft(name: string, content: string) {
+    if (!activeKey) return
+    setTabs((prev) =>
+      prev.map((t) => (t.key === activeKey ? { ...t, draftName: name, draftContent: content } : t)),
+    )
   }
 
   function handleNameChange(val: string) {
     setEditorName(val)
+    updateActiveDraft(val, editorContent)
     onChange({ name: val, content: editorContent })
   }
 
   function handleContentChange(val: string) {
     setEditorContent(val)
+    updateActiveDraft(editorName, val)
     onChange({ name: editorName, content: val })
   }
 
@@ -143,7 +162,9 @@ export function ChecklistTab({ onChange, onSelect, initialDraft, persistedCustom
     if (!activeKey) return
     setTabs((prev) =>
       prev.map((t) =>
-        t.key === activeKey ? { ...t, savedName: editorName, savedContent: editorContent } : t,
+        t.key === activeKey
+          ? { ...t, draftName: editorName, draftContent: editorContent, savedName: editorName, savedContent: editorContent }
+          : t,
       ),
     )
     onSaveCustom?.({ name: editorName, content: editorContent })
@@ -154,6 +175,7 @@ export function ChecklistTab({ onChange, onSelect, initialDraft, persistedCustom
     if (!tab) return
     setEditorName(tab.savedName)
     setEditorContent(tab.savedContent)
+    updateActiveDraft(tab.savedName, tab.savedContent)
     onChange({ name: tab.savedName, content: tab.savedContent })
   }
 
@@ -162,6 +184,8 @@ export function ChecklistTab({ onChange, onSelect, initialDraft, persistedCustom
     const src = customRef.current ?? { name: 'Custom', content: '' }
     const newTab: TabEntry = {
       key,
+      draftName: src.name,
+      draftContent: src.content,
       savedName: src.name,
       savedContent: src.content,
       originalName: src.name,
@@ -185,7 +209,12 @@ export function ChecklistTab({ onChange, onSelect, initialDraft, persistedCustom
         {tabs.map((tab) => {
           const active = tab.key === activeKey
           return (
-            <Tooltip key={tab.key} label={tab.savedName} openDelay={300} withArrow>
+            <Tooltip
+              key={tab.key}
+              label={tab.isQueuedSnapshot ? `${tab.draftName} (queued snapshot)` : tab.draftName}
+              openDelay={300}
+              withArrow
+            >
               <button
                 onClick={() => { loadTab(tab.key); onSelect?.() }}
                 style={{
@@ -201,9 +230,19 @@ export function ChecklistTab({ onChange, onSelect, initialDraft, persistedCustom
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',
                   fontSize: 13,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 6,
                 }}
               >
-                {tab.savedName}
+                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
+                  {tab.draftName}
+                </span>
+                {tab.isQueuedSnapshot && (
+                  <Badge size="xs" variant="light" color="blue" style={{ flexShrink: 0 }}>
+                    queued
+                  </Badge>
+                )}
               </button>
             </Tooltip>
           )

--- a/ui/tests/create/checklist-save.spec.ts
+++ b/ui/tests/create/checklist-save.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect } from 'playwright/test'
+import type { Page } from 'playwright/test'
+import { setupRoutes } from '../helpers/routes'
+
+/**
+ * Tests for the checklist save semantics implemented in ChecklistTab.tsx:
+ * - Tab edits auto-persist within a modal session (switching tabs preserves drafts)
+ * - "Save" persists across modal opens via uiSession.savedCustomTabs
+ * - Queue is NOT an implicit Save
+ * - Editing a queued item shows a pinned "queued" tab with the original snapshot,
+ *   and the same-named current/edited tab remains selectable below it.
+ */
+
+async function openCreateModal(page: Page) {
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Create' }).click()
+  await page.getByRole('button', { name: 'New' }).click()
+  await page.getByText('Create New QC').click()
+  const modal = page.getByRole('dialog', { name: 'Create QC Issue' })
+  await expect(modal).toBeVisible()
+  return modal
+}
+
+async function selectMainRsAndChecklistTab(modal: ReturnType<Page['getByRole']>) {
+  await modal.getByRole('treeitem', { name: 'src' }).click()
+  await modal.getByRole('treeitem', { name: 'main.rs' }).click()
+  await modal.getByRole('tab', { name: 'Select a Checklist' }).click()
+}
+
+test('tab edits auto-persist when switching between checklist tabs within a modal', async ({ page }) => {
+  await setupRoutes(page, { issueStatuses: { results: [], errors: [] } })
+
+  const modal = await openCreateModal(page)
+  await selectMainRsAndChecklistTab(modal)
+
+  // Edit "Code Review" without saving
+  await modal.getByRole('button', { name: 'Code Review' }).click()
+  await modal.locator('textarea').fill('- [ ] Edited code-review (unsaved)')
+
+  // Make a custom tab and put unsaved content on it
+  await modal.getByRole('button', { name: '+ New' }).click()
+  await modal.getByLabel('Name').fill('Scratch')
+  await modal.locator('textarea').fill('- [ ] Scratch draft (unsaved)')
+
+  // Switch back to Code Review — its unsaved edit must still be there
+  await modal.getByRole('button', { name: 'Code Review' }).click()
+  await expect(modal.locator('textarea')).toHaveValue('- [ ] Edited code-review (unsaved)')
+
+  // And switching back to Scratch — its unsaved edit must still be there
+  await modal.getByRole('button', { name: 'Scratch' }).click()
+  await expect(modal.locator('textarea')).toHaveValue('- [ ] Scratch draft (unsaved)')
+})
+
+test('Save persists across modal opens; unsaved edits do not', async ({ page }) => {
+  await setupRoutes(page, { issueStatuses: { results: [], errors: [] } })
+
+  const modal = await openCreateModal(page)
+  await selectMainRsAndChecklistTab(modal)
+
+  // Edit Code Review and Save it
+  await modal.getByRole('button', { name: 'Code Review' }).click()
+  await modal.locator('textarea').fill('- [ ] Saved revision')
+  await modal.getByRole('button', { name: 'Save' }).click()
+
+  // Edit again WITHOUT saving, then close modal
+  await modal.locator('textarea').fill('- [ ] Unsaved revision')
+  await page.keyboard.press('Escape')
+  await expect(modal).not.toBeVisible()
+
+  // Re-open the modal — the saved revision is what loads, not the unsaved one
+  await page.getByText('Create New QC').click()
+  await expect(modal).toBeVisible()
+  await modal.getByRole('treeitem', { name: 'main.rs' }).click()
+  await modal.getByRole('tab', { name: 'Select a Checklist' }).click()
+  await modal.getByRole('button', { name: 'Code Review' }).click()
+  await expect(modal.locator('textarea')).toHaveValue('- [ ] Saved revision')
+})
+
+test('queueing is not an implicit save: next modal open shows last saved content', async ({ page }) => {
+  await setupRoutes(page, { issueStatuses: { results: [], errors: [] } })
+
+  const modal = await openCreateModal(page)
+  await selectMainRsAndChecklistTab(modal)
+
+  // Pick Code Review, edit content, do NOT save, then queue
+  await modal.getByRole('button', { name: 'Code Review' }).click()
+  const original = await modal.locator('textarea').inputValue()
+  await modal.locator('textarea').fill('- [ ] Queued without save')
+  await modal.getByRole('button', { name: 'Queue' }).click()
+  await expect(modal).not.toBeVisible()
+
+  // Open a fresh modal — Code Review should be back to its original content
+  await page.getByText('Create New QC').click()
+  await expect(modal).toBeVisible()
+  await modal.getByRole('treeitem', { name: 'lib.rs' }).click()
+  await modal.getByRole('tab', { name: 'Select a Checklist' }).click()
+  await modal.getByRole('button', { name: 'Code Review' }).click()
+  await expect(modal.locator('textarea')).toHaveValue(original)
+})
+
+test('editing a queued item shows pinned queued snapshot alongside current checklist', async ({ page }) => {
+  await setupRoutes(page, { issueStatuses: { results: [], errors: [] } })
+
+  const modal = await openCreateModal(page)
+  await selectMainRsAndChecklistTab(modal)
+
+  // Queue file_a (main.rs) with the original Code Review checklist
+  await modal.getByRole('button', { name: 'Code Review' }).click()
+  const originalCodeReview = await modal.locator('textarea').inputValue()
+  await modal.getByRole('button', { name: 'Queue' }).click()
+  await expect(modal).not.toBeVisible()
+
+  // Queue file_b (lib.rs) with an edited+saved Code Review
+  await page.getByText('Create New QC').click()
+  await expect(modal).toBeVisible()
+  await modal.getByRole('treeitem', { name: 'lib.rs' }).click()
+  await modal.getByRole('tab', { name: 'Select a Checklist' }).click()
+  await modal.getByRole('button', { name: 'Code Review' }).click()
+  await modal.locator('textarea').fill('- [ ] Edited and saved Code Review')
+  await modal.getByRole('button', { name: 'Save' }).click()
+  await modal.getByRole('button', { name: 'Queue' }).click()
+  await expect(modal).not.toBeVisible()
+
+  // Re-open file_a's queued card (click the card to edit)
+  await page.getByText('src/main.rs').first().click()
+  await expect(modal).toBeVisible()
+  await modal.getByRole('tab', { name: 'Select a Checklist' }).click()
+
+  // The pinned "queued" snapshot tab is active and shows the ORIGINAL content,
+  // not the post-Save edited content.
+  const queuedTab = modal.getByRole('button', { name: 'Code Review queued' })
+  const currentTab = modal.getByRole('button', { name: 'Code Review', exact: true })
+  await expect(queuedTab).toBeVisible()
+  await expect(currentTab).toBeVisible()
+  await expect(modal.locator('textarea')).toHaveValue(originalCodeReview)
+
+  // Switching to the same-named current checklist tab shows the latest saved/edited content.
+  await currentTab.click()
+  await expect(modal.locator('textarea')).toHaveValue('- [ ] Edited and saved Code Review')
+
+  // Switching back to the queued snapshot tab restores the original content.
+  await queuedTab.click()
+  await expect(modal.locator('textarea')).toHaveValue(originalCodeReview)
+})


### PR DESCRIPTION
Based on feedback from users, the checklist persistence was not as desired. A few key issues:

* If a checklist was selected prior, then edited in another issue, the priorly selected checklist would also get updated
* Selecting a different checklist while editing a checklist would clear all non-saved changes

To solve this we have the following semantics:
* A checklist content persists as edited for the duration of a create pop-up modal
* Saving a checklist persists the edit for the duration of the browser
* Any queued checklist is considered unique from the other checklists and is marked as *queued*